### PR TITLE
Add cross-platform build workflow with Windows support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,70 @@
+name: Build & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.2.2)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: windows
+            goarch: amd64
+            ext: .exe
+          - goos: windows
+            goarch: arm64
+            ext: .exe
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+          - goos: darwin
+            goarch: arm64
+            ext: ""
+          - goos: linux
+            goarch: amd64
+            ext: ""
+          - goos: linux
+            goarch: arm64
+            ext: ""
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          go build -ldflags "-s -w -X main.version=${{ inputs.version }}" \
+            -o claude-sync-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} \
+            ./cmd/claude-sync
+      - uses: actions/upload-artifact@v4
+        with:
+          name: claude-sync-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: claude-sync-*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ inputs.version }} \
+            --repo ${{ github.repository }} \
+            --title "claude-sync ${{ inputs.version }}" \
+            --notes "Cross-platform build including Windows binaries." \
+            claude-sync-*


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds releases for Linux, macOS, and Windows (amd64/arm64)
- Enables Windows users to install claude-sync via prebuilt binaries instead of building from source

## Test plan
- [ ] Verify workflow triggers on tag push
- [ ] Confirm binaries are built for all target OS/arch combos
- [ ] Test Windows binary runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)