### PR TITLE
Add configurable exclude list for sync paths

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// Common fields
 	EncryptionKey string `yaml:"encryption_key_path"`
 
+	// Exclude patterns (glob-style) for paths to skip during sync
+	Exclude []string `yaml:"exclude,omitempty"`
+
 	// ClaudeDirOverride allows overriding the default ~/.claude path (for testing)
 	ClaudeDirOverride string `yaml:"-"`
 
@@ -153,4 +156,28 @@ func (c *Config) GetStorageConfig() *storage.StorageConfig {
 // IsLegacyConfig returns true if using the legacy R2-only config format
 func (c *Config) IsLegacyConfig() bool {
 	return c.Storage == nil && c.AccountID != ""
+}
+
+// IsExcluded returns true if the given relative path matches any exclude pattern.
+// Patterns use filepath.Match syntax (e.g. "plugins/marketplace*", "*.tmp").
+// A pattern can also be a plain prefix match (e.g. "plugins/marketplace").
+func (c *Config) IsExcluded(relPath string) bool {
+	for _, pattern := range c.Exclude {
+		// Try glob match
+		matched, err := filepath.Match(pattern, relPath)
+		if err == nil && matched {
+			return true
+		}
+		// Also match if the path starts with the pattern as a directory prefix
+		// This lets "plugins/marketplace" exclude everything under that dir
+		if len(relPath) > len(pattern) && relPath[:len(pattern)] == pattern &&
+			(relPath[len(pattern)] == '/' || relPath[len(pattern)] == '\\') {
+			return true
+		}
+		// Exact match
+		if relPath == pattern {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -143,8 +143,14 @@ func HashFile(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func GetLocalFiles(claudeDir string, syncPaths []string) (map[string]os.FileInfo, error) {
+func GetLocalFiles(claudeDir string, syncPaths []string, excludeFn ...func(string) bool) (map[string]os.FileInfo, error) {
 	files := make(map[string]os.FileInfo)
+
+	// Use the first exclude function if provided
+	var isExcluded func(string) bool
+	if len(excludeFn) > 0 && excludeFn[0] != nil {
+		isExcluded = excludeFn[0]
+	}
 
 	for _, syncPath := range syncPaths {
 		fullPath := filepath.Join(claudeDir, syncPath)
@@ -162,15 +168,27 @@ func GetLocalFiles(claudeDir string, syncPaths []string) (map[string]os.FileInfo
 				if err != nil {
 					return err
 				}
+
+				relPath, _ := filepath.Rel(claudeDir, path)
+				// Normalize to forward slashes for consistent matching
+				relPath = filepath.ToSlash(relPath)
+
+				// Skip excluded directories entirely
 				if fi.IsDir() {
+					if isExcluded != nil && isExcluded(relPath) {
+						return filepath.SkipDir
+					}
 					return nil
 				}
 				// Skip symlinks
 				if fi.Mode()&os.ModeSymlink != 0 {
 					return nil
 				}
+				// Skip excluded files
+				if isExcluded != nil && isExcluded(relPath) {
+					return nil
+				}
 
-				relPath, _ := filepath.Rel(claudeDir, path)
 				files[relPath] = fi
 				return nil
 			})
@@ -180,6 +198,10 @@ func GetLocalFiles(claudeDir string, syncPaths []string) (map[string]os.FileInfo
 		} else {
 			// Skip symlinks
 			if info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+			// Skip excluded files
+			if isExcluded != nil && isExcluded(syncPath) {
 				continue
 			}
 			files[syncPath] = info
@@ -197,10 +219,10 @@ type FileChange struct {
 	LocalTime time.Time
 }
 
-func (s *SyncState) DetectChanges(claudeDir string, syncPaths []string) ([]FileChange, error) {
+func (s *SyncState) DetectChanges(claudeDir string, syncPaths []string, excludeFn ...func(string) bool) ([]FileChange, error) {
 	var changes []FileChange
 
-	localFiles, err := GetLocalFiles(claudeDir, syncPaths)
+	localFiles, err := GetLocalFiles(claudeDir, syncPaths, excludeFn...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -25,6 +25,7 @@ type Syncer struct {
 	claudeDir  string
 	quiet      bool
 	onProgress ProgressFunc
+	cfg        *config.Config
 }
 
 type SyncResult struct {
@@ -82,6 +83,7 @@ func NewSyncer(cfg *config.Config, quiet bool) (*Syncer, error) {
 		state:     state,
 		claudeDir: claudeDir,
 		quiet:     quiet,
+		cfg:       cfg,
 	}, nil
 }
 
@@ -95,6 +97,10 @@ func (s *Syncer) progress(event ProgressEvent) {
 	}
 }
 
+func (s *Syncer) isExcluded(relPath string) bool {
+	return s.cfg.IsExcluded(relPath)
+}
+
 func (s *Syncer) log(format string, args ...interface{}) {
 	if !s.quiet {
 		fmt.Printf(format+"\n", args...)
@@ -106,7 +112,7 @@ func (s *Syncer) Push(ctx context.Context) (*SyncResult, error) {
 
 	s.progress(ProgressEvent{Action: "scan", Path: "Detecting changes..."})
 
-	changes, err := s.state.DetectChanges(s.claudeDir, config.SyncPaths)
+	changes, err := s.state.DetectChanges(s.claudeDir, config.SyncPaths, s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect changes: %w", err)
 	}
@@ -192,11 +198,15 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 			continue
 		}
 		localPath := s.localPath(obj.Key)
+		// Skip excluded paths
+		if s.isExcluded(localPath) {
+			continue
+		}
 		remoteFiles[localPath] = obj
 	}
 
 	// Get current local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths)
+	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -280,7 +290,7 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 }
 
 func (s *Syncer) Status(ctx context.Context) ([]FileChange, error) {
-	return s.state.DetectChanges(s.claudeDir, config.SyncPaths)
+	return s.state.DetectChanges(s.claudeDir, config.SyncPaths, s.isExcluded)
 }
 
 func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
@@ -416,11 +426,14 @@ func (s *Syncer) PreviewPull(ctx context.Context) (*PullPreview, error) {
 			continue
 		}
 		localPath := s.localPath(obj.Key)
+		if s.isExcluded(localPath) {
+			continue
+		}
 		remoteFiles[localPath] = obj
 	}
 
 	// Get current local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths)
+	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -499,7 +512,7 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 	var entries []DiffEntry
 
 	// Get local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths)
+	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -516,6 +529,9 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 			continue
 		}
 		localPath := s.localPath(obj.Key)
+		if s.isExcluded(localPath) {
+			continue
+		}
 		remoteFiles[localPath] = obj
 	}
 


### PR DESCRIPTION
## Summary
- Adds an `exclude` option to `config.yaml` that skips matching paths during push, pull, diff, and status
- Supports glob patterns, prefix matching, and exact matches
- Useful for skipping large read-only directories like plugin caches that don't need syncing

### Example config
```yaml
exclude:
  - plugins/marketplaces   # cached plugin registry clones
  - plugins/cache          # resolved plugin versions
  - "*.tmp"                # glob pattern support
```

### Changes
- `Config` struct gets `Exclude []string` field and `IsExcluded()` method
- `GetLocalFiles` accepts optional exclude function, skips entire directories via `filepath.SkipDir`
- All sync operations (push, pull, diff, status, preview) respect the exclude list on both local and remote sides

## Test plan
- [x] Add exclude entries to config.yaml and verify `claude-sync status` no longer lists them
- [x] Verify push does not upload excluded files
- [x] Verify pull does not download excluded files
- [x] Confirm existing behavior is unchanged when no excludes are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)