### PR TITLE
Gzip compression before encryption for faster transfers

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,8 +1,11 @@
 package sync
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -292,8 +295,14 @@ func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
+	// Compress
+	compressed, err := gzipCompress(data)
+	if err != nil {
+		return fmt.Errorf("failed to compress: %w", err)
+	}
+
 	// Encrypt
-	encrypted, err := s.encryptor.Encrypt(data)
+	encrypted, err := s.encryptor.Encrypt(compressed)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt: %w", err)
 	}
@@ -324,6 +333,14 @@ func (s *Syncer) downloadFile(ctx context.Context, relativePath, remoteKey strin
 	data, err := s.encryptor.Decrypt(encrypted)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt: %w", err)
+	}
+
+	// Decompress if gzipped (backward-compatible with uncompressed data)
+	if isGzipped(data) {
+		data, err = gzipDecompress(data)
+		if err != nil {
+			return fmt.Errorf("failed to decompress: %w", err)
+		}
 	}
 
 	// Ensure directory exists
@@ -578,4 +595,33 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 	}
 
 	return entries, nil
+}
+
+// isGzipped checks if data starts with the gzip magic number (0x1f 0x8b).
+func isGzipped(data []byte) bool {
+	return len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b
+}
+
+func gzipCompress(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w, err := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := w.Write(data); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func gzipDecompress(data []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
 }


### PR DESCRIPTION
## Summary
- Compresses file data with gzip before encrypting, significantly reducing transfer sizes
- Session logs (.jsonl) and other text-heavy content compress 5-10x, meaning faster uploads and downloads
- Backward-compatible: detects gzip magic bytes (0x1f 0x8b) on download and transparently handles both compressed and uncompressed data
- Uses `gzip.BestSpeed` for minimal CPU overhead while still getting most of the compression benefit

### Changes
- `uploadFile`: read -> **compress** -> encrypt -> upload
- `downloadFile`: download -> decrypt -> **decompress if gzipped** -> write
- Added `isGzipped`, `gzipCompress`, `gzipDecompress` helpers

### Backward compatibility
Files uploaded by older versions (uncompressed) are still downloaded correctly. The decompression step only activates when gzip magic bytes are detected.

## Test plan
- [ ] Push files, verify they upload successfully
- [ ] Pull files on another machine (or after clearing state), verify content matches
- [ ] Pull files that were uploaded by an older (non-compressing) version, verify they still work
- [ ] Compare upload times/sizes before and after for large .jsonl files

🤖 Generated with [Claude Code](https://claude.com/claude-code)