### PR TITLE
Add auto-sync command for Claude Code session hooks

### DIFF
--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -2229,11 +2229,11 @@ func (s *settingsJSON) addClaudeSyncHooks() {
 
 	// Add SessionStart -> pull
 	startEntries, _ := hooks["SessionStart"].([]interface{})
-	hooks["SessionStart"] = append(startEntries, makeHookEntry("claude-sync pull --quiet"))
+	hooks["SessionStart"] = append(startEntries, makeHookEntry("claude-sync pull"))
 
 	// Add Stop -> push
 	stopEntries, _ := hooks["Stop"].([]interface{})
-	hooks["Stop"] = append(stopEntries, makeHookEntry("claude-sync push --quiet"))
+	hooks["Stop"] = append(stopEntries, makeHookEntry("claude-sync push"))
 }
 
 func (s *settingsJSON) removeClaudeSyncHooks() {
@@ -2296,8 +2296,8 @@ func autoEnableCmd() *cobra.Command {
 			fmt.Println()
 			fmt.Printf("  %s✓%s Auto-sync hooks installed\n", colorGreen, colorReset)
 			fmt.Println()
-			fmt.Printf("  %sSessionStart%s -> %sclaude-sync pull --quiet%s\n", colorBold, colorReset, colorCyan, colorReset)
-			fmt.Printf("  %sStop%s         -> %sclaude-sync push --quiet%s\n", colorBold, colorReset, colorCyan, colorReset)
+			fmt.Printf("  %sSessionStart%s -> %sclaude-sync pull%s\n", colorBold, colorReset, colorCyan, colorReset)
+			fmt.Printf("  %sStop%s         -> %sclaude-sync push%s\n", colorBold, colorReset, colorCyan, colorReset)
 			fmt.Println()
 			fmt.Printf("  %sClaude Code will now sync automatically on session start and end.%s\n", colorDim, colorReset)
 			fmt.Println()


### PR DESCRIPTION
## Summary
- Adds `claude-sync auto enable/disable/status` subcommands
- When enabled, installs Claude Code hooks that automatically pull on session start and push on session end
- Hooks are written to `~/.claude/settings.json` with a `claude-sync-auto` matcher tag for clean identification and removal
- Idempotent: running `enable` twice is safe, and `disable` cleanly removes only claude-sync hooks while preserving all other settings

### Usage
```bash
claude-sync auto enable    # Install hooks
claude-sync auto disable   # Remove hooks
claude-sync auto status    # Check if enabled
```

### How it works
- **SessionStart** hook runs `claude-sync pull --quiet` before the session becomes interactive
- **Stop** hook runs `claude-sync push --quiet` when the session ends
- This means you always start with the latest data from your other machines, and your changes are pushed when you're done

### Changes
- Added `autoCmd()` with `enable`, `disable`, `status` subcommands
- Added `settingsJSON` helpers for safe read/modify/write of `~/.claude/settings.json`
- Hooks are tagged with `matcher: "claude-sync-auto"` so they can be identified and removed without touching other hooks

## Test plan
- [ ] `claude-sync auto enable` installs hooks correctly
- [ ] `claude-sync auto enable` when already enabled is idempotent
- [ ] `claude-sync auto disable` removes only claude-sync hooks
- [ ] `claude-sync auto status` reports correct state
- [ ] Existing settings (permissions, plugins, etc.) are preserved
- [ ] Start a new Claude Code session and verify pull runs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)