### PR TITLE
feat: add exclude patterns support for sync filtering

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	// Common fields
 	EncryptionKey string `yaml:"encryption_key_path"`
 
+	// Exclude patterns for files/directories to skip during sync
+	// Supports glob patterns (e.g., "plugins/cache/**", "plugins/marketplaces/**")
+	Exclude []string `yaml:"exclude,omitempty"`
+
 	// ClaudeDirOverride allows overriding the default ~/.claude path (for testing)
 	ClaudeDirOverride string `yaml:"-"`
 

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/tawanorg/claude-sync/internal/config"
@@ -143,8 +144,50 @@ func HashFile(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func GetLocalFiles(claudeDir string, syncPaths []string) (map[string]os.FileInfo, error) {
+// shouldExclude checks if a relative path matches any of the exclude patterns.
+// Patterns support filepath.Match glob syntax. Additionally, a pattern ending
+// with "/**" matches the directory and everything under it.
+func shouldExclude(relPath string, excludePatterns []string) bool {
+	for _, pattern := range excludePatterns {
+		// Handle "dir/**" pattern: match anything under that directory
+		if strings.HasSuffix(pattern, "/**") {
+			dirPrefix := strings.TrimSuffix(pattern, "/**")
+			if relPath == dirPrefix || strings.HasPrefix(relPath, dirPrefix+"/") {
+				return true
+			}
+			continue
+		}
+
+		// Try matching the full relative path
+		if matched, _ := filepath.Match(pattern, relPath); matched {
+			return true
+		}
+
+		// Try matching just the filename (for patterns like "*.tmp")
+		if matched, _ := filepath.Match(pattern, filepath.Base(relPath)); matched {
+			return true
+		}
+
+		// Try matching each path component for directory patterns
+		parts := strings.Split(relPath, "/")
+		for i := range parts {
+			partial := strings.Join(parts[:i+1], "/")
+			if matched, _ := filepath.Match(pattern, partial); matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func GetLocalFiles(claudeDir string, syncPaths []string, excludePatterns ...[]string) (map[string]os.FileInfo, error) {
 	files := make(map[string]os.FileInfo)
+
+	// Flatten optional exclude patterns
+	var exclude []string
+	for _, patterns := range excludePatterns {
+		exclude = append(exclude, patterns...)
+	}
 
 	for _, syncPath := range syncPaths {
 		fullPath := filepath.Join(claudeDir, syncPath)
@@ -162,15 +205,25 @@ func GetLocalFiles(claudeDir string, syncPaths []string) (map[string]os.FileInfo
 				if err != nil {
 					return err
 				}
+
+				relPath, _ := filepath.Rel(claudeDir, path)
+
+				// Skip excluded directories early to avoid walking their contents
 				if fi.IsDir() {
+					if len(exclude) > 0 && shouldExclude(relPath, exclude) {
+						return filepath.SkipDir
+					}
 					return nil
 				}
 				// Skip symlinks
 				if fi.Mode()&os.ModeSymlink != 0 {
 					return nil
 				}
+				// Skip excluded files
+				if len(exclude) > 0 && shouldExclude(relPath, exclude) {
+					return nil
+				}
 
-				relPath, _ := filepath.Rel(claudeDir, path)
 				files[relPath] = fi
 				return nil
 			})
@@ -180,6 +233,10 @@ func GetLocalFiles(claudeDir string, syncPaths []string) (map[string]os.FileInfo
 		} else {
 			// Skip symlinks
 			if info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+			// Skip excluded files
+			if len(exclude) > 0 && shouldExclude(syncPath, exclude) {
 				continue
 			}
 			files[syncPath] = info
@@ -197,10 +254,10 @@ type FileChange struct {
 	LocalTime time.Time
 }
 
-func (s *SyncState) DetectChanges(claudeDir string, syncPaths []string) ([]FileChange, error) {
+func (s *SyncState) DetectChanges(claudeDir string, syncPaths []string, excludePatterns ...[]string) ([]FileChange, error) {
 	var changes []FileChange
 
-	localFiles, err := GetLocalFiles(claudeDir, syncPaths)
+	localFiles, err := GetLocalFiles(claudeDir, syncPaths, excludePatterns...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sync/state_test.go
+++ b/internal/sync/state_test.go
@@ -288,6 +288,163 @@ func TestDetectChanges(t *testing.T) {
 	}
 }
 
+func TestShouldExclude(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		patterns []string
+		expected bool
+	}{
+		// Directory wildcard patterns
+		{"exclude dir with /**", "plugins/cache/foo/bar.js", []string{"plugins/cache/**"}, true},
+		{"exclude dir itself", "plugins/cache", []string{"plugins/cache/**"}, true},
+		{"exclude nested dir", "plugins/marketplaces/repo/file.txt", []string{"plugins/marketplaces/**"}, true},
+		{"non-matching dir", "plugins/installed.json", []string{"plugins/cache/**"}, false},
+
+		// Filename glob patterns
+		{"exclude by extension", "projects/foo/debug.tmp", []string{"*.tmp"}, true},
+		{"exclude dotfile", "projects/.DS_Store", []string{".DS_Store"}, true},
+		{"non-matching extension", "projects/foo/file.json", []string{"*.tmp"}, false},
+
+		// Exact path patterns
+		{"exact file match", "debug/log.txt", []string{"debug/log.txt"}, true},
+		{"exact dir pattern", "debug", []string{"debug/**"}, true},
+
+		// Multiple patterns
+		{"first pattern matches", "plugins/cache/mod.js", []string{"plugins/cache/**", "*.tmp"}, true},
+		{"second pattern matches", "foo.tmp", []string{"plugins/cache/**", "*.tmp"}, true},
+		{"no pattern matches", "settings.json", []string{"plugins/cache/**", "*.tmp"}, false},
+
+		// Empty patterns
+		{"empty patterns", "anything.txt", []string{}, false},
+		{"nil-like empty", "anything.txt", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldExclude(tt.path, tt.patterns)
+			if result != tt.expected {
+				t.Errorf("shouldExclude(%q, %v) = %v, want %v", tt.path, tt.patterns, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetLocalFilesWithExclude(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create directory structure mimicking ~/.claude
+	dirs := []string{
+		"plugins/cache/thedotmack/claude-mem",
+		"plugins/marketplaces/repo",
+		"projects/myproject",
+		"agents",
+		"debug",
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+			t.Fatalf("Failed to create dir %s: %v", dir, err)
+		}
+	}
+
+	fileContents := map[string]string{
+		"CLAUDE.md":                                    "# Claude",
+		"settings.json":                                "{}",
+		"plugins/installed_plugins.json":                "{}",
+		"plugins/cache/thedotmack/claude-mem/index.js": "module.exports = {}",
+		"plugins/marketplaces/repo/package.json":        `{"name": "repo"}`,
+		"projects/myproject/memory.md":                  "# Memory",
+		"agents/seo.md":                                "# SEO Agent",
+		"debug/log.txt":                                "debug output",
+	}
+
+	for path, content := range fileContents {
+		if err := os.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", path, err)
+		}
+	}
+
+	syncPaths := []string{"CLAUDE.md", "settings.json", "plugins", "projects", "agents", "debug"}
+
+	// Without exclude — all files found
+	allFiles, err := GetLocalFiles(tmpDir, syncPaths)
+	if err != nil {
+		t.Fatalf("GetLocalFiles failed: %v", err)
+	}
+	if len(allFiles) != len(fileContents) {
+		t.Errorf("Expected %d files without exclude, got %d", len(fileContents), len(allFiles))
+	}
+
+	// With exclude — plugin cache, marketplaces, and debug excluded
+	excludePatterns := []string{"plugins/cache/**", "plugins/marketplaces/**", "debug/**"}
+	filteredFiles, err := GetLocalFiles(tmpDir, syncPaths, excludePatterns)
+	if err != nil {
+		t.Fatalf("GetLocalFiles with exclude failed: %v", err)
+	}
+
+	// Should include: CLAUDE.md, settings.json, installed_plugins.json, memory.md, seo.md
+	expectedIncluded := []string{
+		"CLAUDE.md", "settings.json", "plugins/installed_plugins.json",
+		"projects/myproject/memory.md", "agents/seo.md",
+	}
+	for _, f := range expectedIncluded {
+		if _, ok := filteredFiles[f]; !ok {
+			t.Errorf("Expected file %q to be included after filtering", f)
+		}
+	}
+
+	// Should exclude: cache, marketplaces, debug
+	expectedExcluded := []string{
+		"plugins/cache/thedotmack/claude-mem/index.js",
+		"plugins/marketplaces/repo/package.json",
+		"debug/log.txt",
+	}
+	for _, f := range expectedExcluded {
+		if _, ok := filteredFiles[f]; ok {
+			t.Errorf("Expected file %q to be excluded after filtering, but it was included", f)
+		}
+	}
+
+	if len(filteredFiles) != len(expectedIncluded) {
+		t.Errorf("Expected %d files after exclude, got %d", len(expectedIncluded), len(filteredFiles))
+	}
+}
+
+func TestDetectChangesWithExclude(t *testing.T) {
+	tmpDir := t.TempDir()
+	state := NewState()
+
+	// Create files including some that should be excluded
+	os.MkdirAll(filepath.Join(tmpDir, "plugins/cache"), 0755)
+	files := map[string]string{
+		"settings.json":          "{}",
+		"plugins/cache/big.dat": "lots of data",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", name, err)
+		}
+	}
+
+	// Detect changes with exclude
+	exclude := []string{"plugins/cache/**"}
+	changes, err := state.DetectChanges(tmpDir, []string{"settings.json", "plugins"}, exclude)
+	if err != nil {
+		t.Fatalf("DetectChanges with exclude failed: %v", err)
+	}
+
+	// Only settings.json should be detected
+	if len(changes) != 1 {
+		t.Errorf("Expected 1 change (settings.json only), got %d", len(changes))
+		for _, c := range changes {
+			t.Logf("  change: %s (%s)", c.Path, c.Action)
+		}
+	}
+	if len(changes) == 1 && changes[0].Path != "settings.json" {
+		t.Errorf("Expected change for settings.json, got %s", changes[0].Path)
+	}
+}
+
 func TestGetLocalFilesSkipsSymlinksInDirectories(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -19,12 +19,13 @@ import (
 )
 
 type Syncer struct {
-	storage    storage.Storage
-	encryptor  *crypto.Encryptor
-	state      *SyncState
-	claudeDir  string
-	quiet      bool
-	onProgress ProgressFunc
+	storage         storage.Storage
+	encryptor       *crypto.Encryptor
+	state           *SyncState
+	claudeDir       string
+	quiet           bool
+	onProgress      ProgressFunc
+	excludePatterns []string
 }
 
 type SyncResult struct {
@@ -77,11 +78,12 @@ func NewSyncer(cfg *config.Config, quiet bool) (*Syncer, error) {
 	}
 
 	return &Syncer{
-		storage:   store,
-		encryptor: enc,
-		state:     state,
-		claudeDir: claudeDir,
-		quiet:     quiet,
+		storage:         store,
+		encryptor:       enc,
+		state:           state,
+		claudeDir:       claudeDir,
+		quiet:           quiet,
+		excludePatterns: cfg.Exclude,
 	}, nil
 }
 
@@ -106,7 +108,7 @@ func (s *Syncer) Push(ctx context.Context) (*SyncResult, error) {
 
 	s.progress(ProgressEvent{Action: "scan", Path: "Detecting changes..."})
 
-	changes, err := s.state.DetectChanges(s.claudeDir, config.SyncPaths)
+	changes, err := s.state.DetectChanges(s.claudeDir, config.SyncPaths, s.excludePatterns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect changes: %w", err)
 	}
@@ -196,7 +198,7 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 	}
 
 	// Get current local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths)
+	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.excludePatterns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -280,7 +282,7 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 }
 
 func (s *Syncer) Status(ctx context.Context) ([]FileChange, error) {
-	return s.state.DetectChanges(s.claudeDir, config.SyncPaths)
+	return s.state.DetectChanges(s.claudeDir, config.SyncPaths, s.excludePatterns)
 }
 
 func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
@@ -420,7 +422,7 @@ func (s *Syncer) PreviewPull(ctx context.Context) (*PullPreview, error) {
 	}
 
 	// Get current local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths)
+	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.excludePatterns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -499,7 +501,7 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 	var entries []DiffEntry
 
 	// Get local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths)
+	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.excludePatterns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Adds `exclude` field to `config.yaml` for glob-based file/directory exclusion during sync
- Filters files in `GetLocalFiles()` during `filepath.Walk()`, using `filepath.SkipDir` for excluded directories (avoids walking large trees entirely)
- Backward compatible — no exclude config means current behavior unchanged

Closes #8

## Problem

`~/.claude/` commonly contains 1-2GB of regeneratable data:
- `plugins/cache/` — 700MB+ node_modules (recreated on plugin load)
- `plugins/marketplaces/` — 300MB+ cloned repos (recreated on demand)
- `debug/`, `telemetry/`, `shell-snapshots/` — machine-specific ephemeral data

Without excludes, users must manually delete these before every `claude-sync push`.

## Usage

```yaml
# ~/.claude-sync/config.yaml
storage:
  provider: r2
  bucket: my-bucket
exclude:
  - "plugins/cache/**"
  - "plugins/marketplaces/**"
  - "debug/**"
  - "telemetry/**"
  - "shell-snapshots/**"
  - "paste-cache/**"
```

### Pattern syntax
| Pattern | Matches |
|---|---|
| `dir/**` | Directory and all contents (also skips walking the tree) |
| `*.ext` | Files with extension in any directory |
| `exact/path` | Specific file path |

## Changes

| File | Change |
|---|---|
| `internal/config/config.go` | Add `Exclude []string` field to Config struct |
| `internal/sync/state.go` | Add `shouldExclude()` helper, update `GetLocalFiles()` and `DetectChanges()` to accept exclude patterns |
| `internal/sync/sync.go` | Store exclude patterns in Syncer, pass through to all call sites |
| `internal/sync/state_test.go` | 3 new test functions: `TestShouldExclude` (14 subtests), `TestGetLocalFilesWithExclude`, `TestDetectChangesWithExclude` |

## Test plan

- [x] All 16 existing tests pass
- [x] `TestShouldExclude` — 14 subtests covering dir wildcards, filename globs, exact paths, multiple patterns, empty patterns
- [x] `TestGetLocalFilesWithExclude` — full directory tree with selective exclusion
- [x] `TestDetectChangesWithExclude` — change detection respects exclude patterns
- [x] Full test suite passes: `go test ./internal/... ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)