### PR TITLE
fix: fail init when storage bucket does not exist

### DIFF
--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -358,12 +358,11 @@ skipKeyGen:
 
 	exists, err := store.BucketExists(ctx)
 	if err != nil {
-		printWarning("Could not verify bucket: " + err.Error())
-	} else if exists {
-		printSuccess("Connected to '" + storageCfg.Bucket + "'")
-	} else {
-		printWarning("Bucket '" + storageCfg.Bucket + "' not found")
+		return fmt.Errorf("could not verify bucket '%s': %w", storageCfg.Bucket, err)
+	} else if !exists {
+		return fmt.Errorf("bucket '%s' does not exist. Please create it first in your storage provider's console.\n  For R2: https://dash.cloudflare.com/ → R2 → Create bucket\n  For S3: https://console.aws.amazon.com/s3/ → Create bucket (use 'automatic' location)\n  For GCS: https://console.cloud.google.com/storage/ → Create bucket", storageCfg.Bucket)
 	}
+	printSuccess("Connected to '" + storageCfg.Bucket + "'")
 
 	// Clear remote if user chose to start fresh
 	if shouldClearRemote {

--- a/internal/storage/gcs/gcs.go
+++ b/internal/storage/gcs/gcs.go
@@ -2,6 +2,7 @@ package gcs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -169,7 +170,10 @@ func (c *Client) Head(ctx context.Context, key string) (*appstorage.ObjectInfo, 
 func (c *Client) BucketExists(ctx context.Context) (bool, error) {
 	_, err := c.client.Bucket(c.bucket).Attrs(ctx)
 	if err != nil {
-		return false, nil
+		if errors.Is(err, storage.ErrBucketNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check bucket: %w", err)
 	}
 	return true, nil
 }

--- a/internal/storage/r2/r2.go
+++ b/internal/storage/r2/r2.go
@@ -3,6 +3,7 @@ package r2
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -197,7 +198,12 @@ func (c *Client) BucketExists(ctx context.Context) (bool, error) {
 		Bucket: aws.String(c.bucket),
 	})
 	if err != nil {
-		return false, nil
+		var notFound *types.NotFound
+		var noSuchBucket *types.NoSuchBucket
+		if errors.As(err, &notFound) || errors.As(err, &noSuchBucket) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check bucket: %w", err)
 	}
 	return true, nil
 }

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -197,7 +198,12 @@ func (c *Client) BucketExists(ctx context.Context) (bool, error) {
 		Bucket: aws.String(c.bucket),
 	})
 	if err != nil {
-		return false, nil
+		var notFound *types.NotFound
+		var noSuchBucket *types.NoSuchBucket
+		if errors.As(err, &notFound) || errors.As(err, &noSuchBucket) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check bucket: %w", err)
 	}
 	return true, nil
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
@@ -63,6 +64,60 @@ func (m *MockStorage) BucketExists(ctx context.Context) (bool, error) {
 		return m.BucketExistsFunc(ctx)
 	}
 	return true, nil
+}
+
+func TestMockStorage_BucketExists_NotFound(t *testing.T) {
+	ctx := context.Background()
+	mock := &MockStorage{
+		BucketExistsFunc: func(ctx context.Context) (bool, error) {
+			return false, nil
+		},
+	}
+
+	exists, err := mock.BucketExists(ctx)
+	if err != nil {
+		t.Errorf("BucketExists() error = %v, want nil", err)
+	}
+	if exists {
+		t.Errorf("BucketExists() = true, want false")
+	}
+}
+
+func TestMockStorage_BucketExists_Error(t *testing.T) {
+	ctx := context.Background()
+	mock := &MockStorage{
+		BucketExistsFunc: func(ctx context.Context) (bool, error) {
+			return false, fmt.Errorf("failed to check bucket: access denied")
+		},
+	}
+
+	exists, err := mock.BucketExists(ctx)
+	if err == nil {
+		t.Errorf("BucketExists() error = nil, want error")
+	}
+	if exists {
+		t.Errorf("BucketExists() = true, want false")
+	}
+	if !contains(err.Error(), "access denied") {
+		t.Errorf("BucketExists() error = %v, want error containing 'access denied'", err)
+	}
+}
+
+func TestMockStorage_BucketExists_Success(t *testing.T) {
+	ctx := context.Background()
+	mock := &MockStorage{
+		BucketExistsFunc: func(ctx context.Context) (bool, error) {
+			return true, nil
+		},
+	}
+
+	exists, err := mock.BucketExists(ctx)
+	if err != nil {
+		t.Errorf("BucketExists() error = %v, want nil", err)
+	}
+	if !exists {
+		t.Errorf("BucketExists() = false, want true")
+	}
 }
 
 func TestNew_InvalidConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- Init now fails with an actionable error when the configured bucket doesn't exist, instead of silently completing setup
- `BucketExists` in R2/S3/GCS backends now properly distinguishes "not found" from other errors (auth failures, network issues) using typed error checks
- Added unit tests for `BucketExists` error propagation behavior

Closes #21