### PR TITLE
refactor: replace postinstall with platform-specific npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,23 +42,34 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 
-      - name: Publish to npm
+      - name: Build platform binaries
+        if: success()
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$VERSION" ]; then
+            LDFLAGS="-s -w -X main.version=${VERSION}"
+            GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o bin/claude-sync-darwin-arm64 ./cmd/claude-sync
+            GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o bin/claude-sync-darwin-amd64 ./cmd/claude-sync
+            GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o bin/claude-sync-linux-arm64 ./cmd/claude-sync
+            GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o bin/claude-sync-linux-amd64 ./cmd/claude-sync
+            GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o bin/claude-sync-windows-amd64.exe ./cmd/claude-sync
+            GOOS=windows GOARCH=arm64 go build -ldflags "$LDFLAGS" -o bin/claude-sync-windows-arm64.exe ./cmd/claude-sync
+          fi
+
+      - name: Publish platform packages to npm
         if: success()
         continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          # Get the latest version from git tag
           VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$VERSION" ]; then
-            # Check if version already published
             PUBLISHED=$(npm view @tawandotorg/claude-sync version 2>/dev/null || echo "")
             if [ "${VERSION#v}" = "$PUBLISHED" ]; then
               echo "Version ${VERSION#v} already published to npm, skipping"
               exit 0
             fi
-            npm version ${VERSION#v} --no-git-tag-version --allow-same-version
-            npm publish --access public
+            bash scripts/publish-npm.sh "$VERSION"
           fi
 
       - name: Publish to GitHub Packages

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 bin/claude-sync
 bin/claude-sync.exe
 bin/claude-sync-*
+
+# Platform package binaries (added during publish, not committed)
+npm/*/claude-sync
+npm/*/claude-sync.exe
 *.exe
 *.exe~
 *.dll

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Release](https://img.shields.io/github/v/release/tawanorg/claude-sync)](https://github.com/tawanorg/claude-sync/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![npm](https://img.shields.io/npm/v/@tawandotorg/claude-sync)](https://www.npmjs.com/package/@tawandotorg/claude-sync)
+[![Socket Badge](https://badge.socket.dev/npm/package/@tawandotorg/claude-sync/1.8.0)](https://badge.socket.dev/npm/package/@tawandotorg/claude-sync/1.8.0)
 
 [Quick Start](#quick-start) • [Setup Guide](#setup-guide) • [Commands](#commands) • [Auto-Sync](#auto-sync-hooks) • [Security](#security)
 

--- a/bin/claude-sync.js
+++ b/bin/claude-sync.js
@@ -4,18 +4,48 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 
-function getBinaryPath() {
-  const platform = process.platform;
-  const binaryName = platform === "win32" ? "claude-sync.exe" : "claude-sync";
-  const binaryPath = path.join(__dirname, binaryName);
+const PLATFORM_PACKAGES = {
+  "darwin-arm64": "@tawandotorg/claude-sync-darwin-arm64",
+  "darwin-x64": "@tawandotorg/claude-sync-darwin-x64",
+  "linux-arm64": "@tawandotorg/claude-sync-linux-arm64",
+  "linux-x64": "@tawandotorg/claude-sync-linux-x64",
+  "win32-arm64": "@tawandotorg/claude-sync-win32-arm64",
+  "win32-x64": "@tawandotorg/claude-sync-win32-x64",
+};
 
-  if (!fs.existsSync(binaryPath)) {
-    console.error("Error: claude-sync binary not found.");
-    console.error("Try reinstalling: npm install -g claude-sync");
+function getBinaryPath() {
+  const platformKey = `${process.platform}-${process.arch}`;
+  const packageName = PLATFORM_PACKAGES[platformKey];
+
+  if (!packageName) {
+    console.error(`Error: Unsupported platform ${platformKey}`);
+    console.error("Supported: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64");
     process.exit(1);
   }
 
-  return binaryPath;
+  const binaryName = process.platform === "win32" ? "claude-sync.exe" : "claude-sync";
+
+  // Try to find the binary from the platform-specific package
+  try {
+    const packageDir = path.dirname(require.resolve(`${packageName}/package.json`));
+    const binaryPath = path.join(packageDir, binaryName);
+    if (fs.existsSync(binaryPath)) {
+      return binaryPath;
+    }
+  } catch (e) {
+    // Package not installed
+  }
+
+  // Fallback: check local bin directory (for development)
+  const localPath = path.join(__dirname, binaryName);
+  if (fs.existsSync(localPath)) {
+    return localPath;
+  }
+
+  console.error(`Error: claude-sync binary not found for ${platformKey}.`);
+  console.error(`The platform package ${packageName} may not be installed.`);
+  console.error("Try reinstalling: npm install -g @tawandotorg/claude-sync");
+  process.exit(1);
 }
 
 const binary = getBinaryPath();

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -1140,7 +1140,6 @@ func diffCmd() *cobra.Command {
 	}
 }
 
-
 type conflictFile struct {
 	ConflictPath string
 	OriginalPath string
@@ -1674,7 +1673,6 @@ func getLatestRelease() (*GitHubRelease, error) {
 	return &release, nil
 }
 
-
 func downloadBinary(url string) ([]byte, error) {
 	client := &http.Client{Timeout: 5 * time.Minute}
 	resp, err := client.Get(url)
@@ -1716,8 +1714,6 @@ func replaceBinary(execPath string, newBinary []byte) error {
 
 	return nil
 }
-
-
 
 // verifyKeyMatchesRemote checks if the encryption key can decrypt existing remote files.
 // Returns nil if no files exist or if decryption succeeds.

--- a/internal/sync/mcp_test.go
+++ b/internal/sync/mcp_test.go
@@ -259,9 +259,9 @@ func TestMergeMCPServers_KeepLocalChanged(t *testing.T) {
 	serverV1 := json.RawMessage(`{"command":"node","args":["v1"]}`)
 	serverV2 := json.RawMessage(`{"command":"node","args":["v2"]}`)
 
-	local := MCPServers{"s": serverV2}     // local changed
-	remote := MCPServers{"s": serverV1}    // remote unchanged
-	baseline := MCPServers{"s": serverV1}  // matches remote
+	local := MCPServers{"s": serverV2}    // local changed
+	remote := MCPServers{"s": serverV1}   // remote unchanged
+	baseline := MCPServers{"s": serverV1} // matches remote
 
 	result := MergeMCPServers(local, remote, baseline)
 

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tawandotorg/claude-sync-darwin-arm64",
+  "version": "0.4.0",
+  "description": "claude-sync binary for macOS ARM64",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "bin": {
+    "claude-sync": "claude-sync"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tawanorg/claude-sync.git"
+  }
+}

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tawandotorg/claude-sync-darwin-x64",
+  "version": "0.4.0",
+  "description": "claude-sync binary for macOS x64",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "bin": {
+    "claude-sync": "claude-sync"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tawanorg/claude-sync.git"
+  }
+}

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tawandotorg/claude-sync-linux-arm64",
+  "version": "0.4.0",
+  "description": "claude-sync binary for Linux ARM64",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "bin": {
+    "claude-sync": "claude-sync"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tawanorg/claude-sync.git"
+  }
+}

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tawandotorg/claude-sync-linux-x64",
+  "version": "0.4.0",
+  "description": "claude-sync binary for Linux x64",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "bin": {
+    "claude-sync": "claude-sync"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tawanorg/claude-sync.git"
+  }
+}

--- a/npm/win32-arm64/package.json
+++ b/npm/win32-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tawandotorg/claude-sync-win32-arm64",
+  "version": "0.4.0",
+  "description": "claude-sync binary for Windows ARM64",
+  "os": ["win32"],
+  "cpu": ["arm64"],
+  "bin": {
+    "claude-sync": "claude-sync.exe"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tawanorg/claude-sync.git"
+  }
+}

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tawandotorg/claude-sync-win32-x64",
+  "version": "0.4.0",
+  "description": "claude-sync binary for Windows x64",
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "bin": {
+    "claude-sync": "claude-sync.exe"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tawanorg/claude-sync.git"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "bin": {
     "claude-sync": "./bin/claude-sync.js"
   },
-  "scripts": {
-    "postinstall": "node install.js"
-  },
   "keywords": [
     "claude",
     "claude-code",
@@ -33,13 +30,12 @@
   "engines": {
     "node": ">=14"
   },
-  "os": [
-    "darwin",
-    "linux",
-    "win32"
-  ],
-  "cpu": [
-    "x64",
-    "arm64"
-  ]
+  "optionalDependencies": {
+    "@tawandotorg/claude-sync-darwin-arm64": "0.4.0",
+    "@tawandotorg/claude-sync-darwin-x64": "0.4.0",
+    "@tawandotorg/claude-sync-linux-arm64": "0.4.0",
+    "@tawandotorg/claude-sync-linux-x64": "0.4.0",
+    "@tawandotorg/claude-sync-win32-arm64": "0.4.0",
+    "@tawandotorg/claude-sync-win32-x64": "0.4.0"
+  }
 }

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+# Publish platform-specific npm packages for claude-sync
+# Usage: ./scripts/publish-npm.sh <version>
+# Expects binaries in bin/ directory (from build-all or CI artifacts)
+
+VERSION="${1:?Usage: publish-npm.sh <version>}"
+VERSION="${VERSION#v}" # Strip v prefix
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+NPM_DIR="$ROOT_DIR/npm"
+
+# Map: npm platform → Go binary name
+declare -A PLATFORM_MAP=(
+  ["darwin-arm64"]="claude-sync-darwin-arm64"
+  ["darwin-x64"]="claude-sync-darwin-amd64"
+  ["linux-arm64"]="claude-sync-linux-arm64"
+  ["linux-x64"]="claude-sync-linux-amd64"
+  ["win32-arm64"]="claude-sync-windows-arm64.exe"
+  ["win32-x64"]="claude-sync-windows-amd64.exe"
+)
+
+# Binary name per platform
+declare -A BINARY_NAME=(
+  ["darwin-arm64"]="claude-sync"
+  ["darwin-x64"]="claude-sync"
+  ["linux-arm64"]="claude-sync"
+  ["linux-x64"]="claude-sync"
+  ["win32-arm64"]="claude-sync.exe"
+  ["win32-x64"]="claude-sync.exe"
+)
+
+for platform in "${!PLATFORM_MAP[@]}"; do
+  src_binary="${PLATFORM_MAP[$platform]}"
+  dst_binary="${BINARY_NAME[$platform]}"
+  pkg_dir="$NPM_DIR/$platform"
+
+  echo "Publishing @tawandotorg/claude-sync-${platform}@${VERSION}..."
+
+  # Copy binary into package directory
+  if [ -f "$ROOT_DIR/bin/$src_binary" ]; then
+    cp "$ROOT_DIR/bin/$src_binary" "$pkg_dir/$dst_binary"
+    chmod +x "$pkg_dir/$dst_binary"
+  elif [ -f "$ROOT_DIR/$src_binary" ]; then
+    cp "$ROOT_DIR/$src_binary" "$pkg_dir/$dst_binary"
+    chmod +x "$pkg_dir/$dst_binary"
+  else
+    echo "  WARNING: Binary $src_binary not found, skipping $platform"
+    continue
+  fi
+
+  # Update version in package.json
+  cd "$pkg_dir"
+  npm version "$VERSION" --no-git-tag-version --allow-same-version 2>/dev/null
+  npm publish --access public
+  echo "  Published!"
+
+  # Clean up binary (don't commit binaries)
+  rm -f "$pkg_dir/$dst_binary"
+done
+
+# Publish main package
+echo "Publishing @tawandotorg/claude-sync@${VERSION}..."
+cd "$ROOT_DIR"
+
+# Update optionalDependencies versions
+for platform in "${!PLATFORM_MAP[@]}"; do
+  sed -i.bak "s|\"@tawandotorg/claude-sync-${platform}\": \".*\"|\"@tawandotorg/claude-sync-${platform}\": \"${VERSION}\"|" package.json
+done
+rm -f package.json.bak
+
+npm version "$VERSION" --no-git-tag-version --allow-same-version 2>/dev/null
+npm publish --access public
+echo "Published @tawandotorg/claude-sync@${VERSION}!"


### PR DESCRIPTION
## Summary
- Eliminates Socket.dev `installScripts` alert by removing the `postinstall` hook that downloaded binaries at install time
- Uses platform-specific optional dependencies (like esbuild/turbo) so npm installs only the matching binary package based on os/cpu
- Added 6 platform packages: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64
- Updated release workflow to build and publish all platform packages before the main package
- Added Socket badge to README