### PR TITLE
feat: add WebDAV storage provider (Nextcloud, ownCloud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <br>
 
-*Encrypted with [age](https://github.com/FiloSottile/age) • R2 / S3 / GCS supported*
+*Encrypted with [age](https://github.com/FiloSottile/age) • R2 / S3 / GCS / WebDAV supported*
 
 [![Release](https://img.shields.io/github/v/release/tawanorg/claude-sync)](https://github.com/tawanorg/claude-sync/releases)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -20,7 +20,7 @@
 ## Features
 
 - **Cross-device sync**: Continue Claude Code conversations on any laptop
-- **Multi-provider storage**: Cloudflare R2, AWS S3, or Google Cloud Storage
+- **Multi-provider storage**: Cloudflare R2, AWS S3, Google Cloud Storage, or WebDAV (Nextcloud, ownCloud)
 - **End-to-end encryption**: All files encrypted with age before upload
 - **Passphrase-based keys**: Same passphrase = same key on any device (no file copying)
 - **Interactive wizard**: Arrow-key driven setup with validation
@@ -56,7 +56,7 @@ npm install -g @tawandotorg/claude-sync
 
 # Set up with SAME storage credentials
 claude-sync init
-# Select same provider (R2/S3/GCS)
+# Select same provider (R2/S3/GCS/WebDAV)
 # Enter same bucket name and credentials
 # Choose "Passphrase" for encryption
 # Enter the SAME passphrase as first device
@@ -80,6 +80,7 @@ claude-sync pull
 | **Cloudflare R2** | 10GB storage | Personal use (recommended) |
 | **AWS S3** | 5GB (12 months) | AWS users |
 | **Google Cloud Storage** | 5GB | GCP users |
+| **WebDAV** | Self-hosted (unlimited) | Nextcloud/ownCloud users |
 
 ### Step 2: Create a Bucket
 
@@ -114,6 +115,19 @@ You'll need: Access Key ID, Secret Access Key, Region
 You'll need: Project ID, Service Account JSON file (or use `gcloud auth application-default login`)
 </details>
 
+<details>
+<summary><b>WebDAV (Nextcloud, ownCloud, etc.)</b></summary>
+
+No bucket to create — just point at your existing WebDAV server.
+
+1. **Nextcloud**: Go to Settings → Security → Devices & sessions → Create app password
+2. Note your WebDAV URL: `https://your-server/remote.php/dav/files/USERNAME/`
+
+You'll need: WebDAV URL, Username, App password
+
+The wizard will create a `claude-sync` subdirectory automatically.
+</details>
+
 ### Step 3: Run Init
 
 ```bash
@@ -122,7 +136,7 @@ claude-sync init
 
 The interactive wizard will guide you through:
 
-1. **Select storage provider** (R2, S3, or GCS)
+1. **Select storage provider** (R2, S3, GCS, or WebDAV)
 2. **Enter credentials** (provider-specific)
 3. **Choose encryption method**:
    - **Passphrase** (recommended) - same passphrase on all devices = same key
@@ -346,6 +360,7 @@ Claude sessions typically use < 50MB. Syncing is effectively **free** on any pro
 | **Cloudflare R2** | 10GB storage, 1M writes, 10M reads/month |
 | **AWS S3** | 5GB for 12 months (then ~$0.023/GB) |
 | **Google Cloud Storage** | 5GB, 5K writes, 50K reads/month |
+| **WebDAV** | Self-hosted — no limits, no cost beyond your own server |
 
 ## Installation Options
 

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/tawanorg/claude-sync/internal/storage/gcs"
 	_ "github.com/tawanorg/claude-sync/internal/storage/r2"
 	_ "github.com/tawanorg/claude-sync/internal/storage/s3"
+	_ "github.com/tawanorg/claude-sync/internal/storage/webdav"
 )
 
 var (
@@ -122,15 +123,19 @@ func initCmd() *cobra.Command {
 	// GCS flags
 	var gcsProjectID, gcsCredentialsFile string
 
+	// WebDAV flags
+	var webdavURL, webdavUsername, webdavPassword, webdavPathPrefix string
+
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize claude-sync configuration",
 		Long: `Set up cloud storage credentials and generate encryption keys.
 
 Supported providers:
-  - r2:  Cloudflare R2 (S3-compatible, free tier: 10GB)
-  - s3:  Amazon S3
-  - gcs: Google Cloud Storage
+  - r2:     Cloudflare R2 (S3-compatible, free tier: 10GB)
+  - s3:     Amazon S3
+  - gcs:    Google Cloud Storage
+  - webdav: WebDAV (Nextcloud, ownCloud, etc. - self-hosted)
 
 Examples:
   claude-sync init                # Full setup wizard
@@ -149,12 +154,12 @@ Examples:
 			}
 
 			// Normal flow: full setup
-			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile, usePassphrase, force)
+			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile, webdavURL, webdavUsername, webdavPassword, webdavPathPrefix, usePassphrase, force)
 		},
 	}
 
 	// Provider selection
-	cmd.Flags().StringVar(&provider, "provider", "", "Storage provider: r2, s3, or gcs")
+	cmd.Flags().StringVar(&provider, "provider", "", "Storage provider: r2, s3, gcs, or webdav")
 	cmd.Flags().StringVar(&bucket, "bucket", "", "Bucket name")
 	cmd.Flags().BoolVar(&usePassphrase, "passphrase", false, "Derive encryption key from passphrase")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing config/key without prompting")
@@ -170,6 +175,12 @@ Examples:
 	// GCS flags
 	cmd.Flags().StringVar(&gcsProjectID, "project-id", "", "GCP Project ID (GCS)")
 	cmd.Flags().StringVar(&gcsCredentialsFile, "credentials-file", "", "Path to GCS credentials JSON file")
+
+	// WebDAV flags
+	cmd.Flags().StringVar(&webdavURL, "webdav-url", "", "WebDAV URL (e.g. https://cloud.example.com/remote.php/dav/files/user/)")
+	cmd.Flags().StringVar(&webdavUsername, "webdav-username", "", "WebDAV username")
+	cmd.Flags().StringVar(&webdavPassword, "webdav-password", "", "WebDAV app password")
+	cmd.Flags().StringVar(&webdavPathPrefix, "webdav-path-prefix", "claude-sync", "WebDAV path prefix (subdirectory)")
 
 	return cmd
 }
@@ -216,7 +227,7 @@ func initPassphraseOnly(ctx context.Context, keyPath string) error {
 }
 
 // initFullSetup handles the full init wizard
-func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile string, usePassphrase, force bool) error {
+func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile, webdavURL, webdavUsername, webdavPassword, webdavPathPrefix string, usePassphrase, force bool) error {
 	if config.Exists() && !force {
 		var overwrite bool
 		prompt := &survey.Confirm{
@@ -241,6 +252,7 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 				"Cloudflare R2 (recommended - free tier: 10GB)",
 				"Amazon S3",
 				"Google Cloud Storage",
+				"WebDAV (Nextcloud, ownCloud, etc. - self-hosted)",
 			},
 		}
 		var choice int
@@ -254,6 +266,8 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 			provider = "s3"
 		case 2:
 			provider = "gcs"
+		case 3:
+			provider = "webdav"
 		}
 	}
 
@@ -268,6 +282,8 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 		storageCfg, err = runS3Wizard(accessKey, secretKey, s3Region, bucket)
 	case "gcs":
 		storageCfg, err = runGCSWizard(gcsProjectID, gcsCredentialsFile, bucket)
+	case "webdav":
+		storageCfg, err = runWebDAVWizard(webdavURL, webdavUsername, webdavPassword, webdavPathPrefix)
 	default:
 		return fmt.Errorf("unsupported provider: %s", provider)
 	}
@@ -362,9 +378,16 @@ skipKeyGen:
 	if err != nil {
 		return fmt.Errorf("could not verify bucket '%s': %w", storageCfg.Bucket, err)
 	} else if !exists {
+		if storageCfg.Provider == storage.ProviderWebDAV {
+			return fmt.Errorf("could not access WebDAV path '%s' - check your URL and credentials", storageCfg.PathPrefix)
+		}
 		return fmt.Errorf("bucket '%s' does not exist. Please create it first in your storage provider's console.\n  For R2: https://dash.cloudflare.com/ → R2 → Create bucket\n  For S3: https://console.aws.amazon.com/s3/ → Create bucket (use 'automatic' location)\n  For GCS: https://console.cloud.google.com/storage/ → Create bucket", storageCfg.Bucket)
 	}
-	printSuccess("Connected to '" + storageCfg.Bucket + "'")
+	if storageCfg.Provider == storage.ProviderWebDAV {
+		printSuccess("Connected to WebDAV ('" + storageCfg.PathPrefix + "')")
+	} else {
+		printSuccess("Connected to '" + storageCfg.Bucket + "'")
+	}
 
 	// Clear remote if user chose to start fresh
 	if shouldClearRemote {
@@ -736,6 +759,91 @@ func runGCSWizard(projectID, credentialsFile, bucket string) (*storage.StorageCo
 		cfg.CredentialsFile = credPath
 	} else {
 		cfg.UseDefaultCredentials = true
+	}
+
+	return cfg, nil
+}
+
+func runWebDAVWizard(webdavURL, username, password, pathPrefix string) (*storage.StorageConfig, error) {
+	fmt.Printf("  %sWebDAV Setup (Nextcloud, ownCloud, etc.)%s\n\n", colorBold, colorReset)
+	printInfo("You need a WebDAV server URL, username, and an app password.")
+	fmt.Println()
+	fmt.Printf("  %sNextcloud:%s Go to Settings → Security → Devices & sessions\n", colorCyan, colorReset)
+	printInfo("  to create an app password (recommended over your account password)")
+	fmt.Println()
+	fmt.Printf("  %sURL format:%s https://cloud.example.com/remote.php/dav/files/USERNAME/\n", colorCyan, colorReset)
+	fmt.Println()
+
+	answers := struct {
+		URL        string
+		Username   string
+		Password   string
+		PathPrefix string
+	}{
+		URL:        webdavURL,
+		Username:   username,
+		Password:   password,
+		PathPrefix: pathPrefix,
+	}
+
+	questions := []*survey.Question{
+		{
+			Name: "URL",
+			Prompt: &survey.Input{
+				Message: "WebDAV URL:",
+				Default: webdavURL,
+				Help:    "For Nextcloud: https://your-server/remote.php/dav/files/USERNAME/",
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "Username",
+			Prompt: &survey.Input{
+				Message: "Username:",
+				Default: username,
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "Password",
+			Prompt: &survey.Password{
+				Message: "App password:",
+				Help:    "Use an app-specific password, not your account password",
+			},
+		},
+		{
+			Name: "PathPrefix",
+			Prompt: &survey.Input{
+				Message: "Path prefix (subdirectory for sync data):",
+				Default: func() string {
+					if pathPrefix != "" {
+						return pathPrefix
+					}
+					return "claude-sync"
+				}(),
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	if err := survey.Ask(questions, &answers); err != nil {
+		return nil, err
+	}
+
+	if answers.Password == "" && password != "" {
+		answers.Password = password
+	}
+	if answers.Password == "" {
+		return nil, fmt.Errorf("app password is required")
+	}
+
+	cfg := &storage.StorageConfig{
+		Provider:       storage.ProviderWebDAV,
+		Bucket:         answers.PathPrefix,
+		WebDAVURL:      answers.URL,
+		WebDAVUsername:  answers.Username,
+		WebDAVPassword: answers.Password,
+		PathPrefix:     answers.PathPrefix,
 	}
 
 	return cfg, nil

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -23,11 +23,17 @@ type StorageConfig struct {
 	CredentialsFile       string `yaml:"credentials_file,omitempty"`
 	CredentialsJSON       string `yaml:"credentials_json,omitempty"`
 	UseDefaultCredentials bool   `yaml:"use_default_credentials,omitempty"`
+
+	// WebDAV-specific (Nextcloud, ownCloud, etc.)
+	WebDAVURL      string `yaml:"webdav_url,omitempty"`
+	WebDAVUsername string `yaml:"webdav_username,omitempty"`
+	WebDAVPassword string `yaml:"webdav_password,omitempty"`
+	PathPrefix     string `yaml:"path_prefix,omitempty"`
 }
 
 // Validate checks if the configuration is valid for the selected provider
 func (c *StorageConfig) Validate() error {
-	if c.Bucket == "" {
+	if c.Provider != ProviderWebDAV && c.Bucket == "" {
 		return fmt.Errorf("bucket is required")
 	}
 
@@ -38,6 +44,8 @@ func (c *StorageConfig) Validate() error {
 		return c.validateS3()
 	case ProviderGCS:
 		return c.validateGCS()
+	case ProviderWebDAV:
+		return c.validateWebDAV()
 	case "":
 		return fmt.Errorf("provider is required")
 	default:
@@ -77,6 +85,19 @@ func (c *StorageConfig) validateGCS() error {
 	}
 	// GCS can use default credentials, credentials file, or JSON
 	// At least one auth method should be available (or use_default_credentials)
+	return nil
+}
+
+func (c *StorageConfig) validateWebDAV() error {
+	if c.WebDAVURL == "" {
+		return fmt.Errorf("webdav_url is required for WebDAV")
+	}
+	if c.WebDAVUsername == "" {
+		return fmt.Errorf("webdav_username is required for WebDAV")
+	}
+	if c.WebDAVPassword == "" {
+		return fmt.Errorf("webdav_password is required for WebDAV")
+	}
 	return nil
 }
 

--- a/internal/storage/config_test.go
+++ b/internal/storage/config_test.go
@@ -153,6 +153,58 @@ func TestStorageConfig_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "project_id is required",
 		},
+		// WebDAV tests
+		{
+			name: "valid WebDAV config",
+			config: StorageConfig{
+				Provider:       ProviderWebDAV,
+				WebDAVURL:      "https://cloud.example.com/remote.php/dav/files/user/",
+				WebDAVUsername:  "user",
+				WebDAVPassword: "app-password",
+				PathPrefix:     "claude-sync",
+			},
+			wantErr: false,
+		},
+		{
+			name: "WebDAV missing URL",
+			config: StorageConfig{
+				Provider:       ProviderWebDAV,
+				WebDAVUsername:  "user",
+				WebDAVPassword: "app-password",
+			},
+			wantErr: true,
+			errMsg:  "webdav_url is required",
+		},
+		{
+			name: "WebDAV missing username",
+			config: StorageConfig{
+				Provider:       ProviderWebDAV,
+				WebDAVURL:      "https://cloud.example.com/remote.php/dav/files/user/",
+				WebDAVPassword: "app-password",
+			},
+			wantErr: true,
+			errMsg:  "webdav_username is required",
+		},
+		{
+			name: "WebDAV missing password",
+			config: StorageConfig{
+				Provider:      ProviderWebDAV,
+				WebDAVURL:     "https://cloud.example.com/remote.php/dav/files/user/",
+				WebDAVUsername: "user",
+			},
+			wantErr: true,
+			errMsg:  "webdav_password is required",
+		},
+		{
+			name: "WebDAV does not require bucket",
+			config: StorageConfig{
+				Provider:       ProviderWebDAV,
+				WebDAVURL:      "https://cloud.example.com/remote.php/dav/files/user/",
+				WebDAVUsername:  "user",
+				WebDAVPassword: "app-password",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -10,9 +10,10 @@ import (
 type Provider string
 
 const (
-	ProviderR2  Provider = "r2"
-	ProviderS3  Provider = "s3"
-	ProviderGCS Provider = "gcs"
+	ProviderR2     Provider = "r2"
+	ProviderS3     Provider = "s3"
+	ProviderGCS    Provider = "gcs"
+	ProviderWebDAV Provider = "webdav"
 )
 
 // ObjectInfo contains metadata about a stored object
@@ -60,6 +61,8 @@ func New(cfg *StorageConfig) (Storage, error) {
 		return NewS3(cfg)
 	case ProviderGCS:
 		return NewGCS(cfg)
+	case ProviderWebDAV:
+		return NewWebDAV(cfg)
 	default:
 		return nil, fmt.Errorf("unsupported storage provider: %s", cfg.Provider)
 	}
@@ -73,3 +76,6 @@ var NewS3 func(cfg *StorageConfig) (Storage, error)
 
 // NewGCS creates a new GCS storage adapter (implemented in gcs/gcs.go)
 var NewGCS func(cfg *StorageConfig) (Storage, error)
+
+// NewWebDAV creates a new WebDAV storage adapter (implemented in webdav/webdav.go)
+var NewWebDAV func(cfg *StorageConfig) (Storage, error)

--- a/internal/storage/webdav/propfind.go
+++ b/internal/storage/webdav/propfind.go
@@ -1,0 +1,87 @@
+package webdav
+
+import (
+	"encoding/xml"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type propfindMultistatus struct {
+	XMLName   xml.Name             `xml:"multistatus"`
+	Responses []propfindRespEntry  `xml:"response"`
+}
+
+type propfindRespEntry struct {
+	Href     string            `xml:"href"`
+	Propstat []propfindPropstat `xml:"propstat"`
+}
+
+type propfindPropstat struct {
+	Prop   propfindProp `xml:"prop"`
+	Status string       `xml:"status"`
+}
+
+type propfindProp struct {
+	ContentLength int64            `xml:"getcontentlength"`
+	LastModified  string           `xml:"getlastmodified"`
+	ETag          string           `xml:"getetag"`
+	ResourceType  propResourceType `xml:"resourcetype"`
+}
+
+type propResourceType struct {
+	Collection *struct{} `xml:"collection"`
+}
+
+type parsedResponse struct {
+	Href          string
+	ContentLength int64
+	LastModified  time.Time
+	ETag          string
+	IsCollection  bool
+}
+
+func parsePropfindResponse(data []byte) ([]parsedResponse, error) {
+	var ms propfindMultistatus
+	if err := xml.Unmarshal(data, &ms); err != nil {
+		return nil, err
+	}
+
+	var results []parsedResponse
+	for _, entry := range ms.Responses {
+		r := parsedResponse{}
+
+		href := entry.Href
+		if decoded, err := url.PathUnescape(href); err == nil {
+			href = decoded
+		}
+		r.Href = href
+
+		for _, ps := range entry.Propstat {
+			if !strings.Contains(ps.Status, "200") {
+				continue
+			}
+			r.ContentLength = ps.Prop.ContentLength
+			r.ETag = strings.Trim(ps.Prop.ETag, "\"")
+			r.IsCollection = ps.Prop.ResourceType.Collection != nil
+
+			if ps.Prop.LastModified != "" {
+				for _, layout := range []string{
+					time.RFC1123,
+					time.RFC1123Z,
+					"Mon, 02 Jan 2006 15:04:05 GMT",
+					time.RFC3339,
+				} {
+					if t, err := time.Parse(layout, ps.Prop.LastModified); err == nil {
+						r.LastModified = t
+						break
+					}
+				}
+			}
+		}
+
+		results = append(results, r)
+	}
+
+	return results, nil
+}

--- a/internal/storage/webdav/propfind_test.go
+++ b/internal/storage/webdav/propfind_test.go
@@ -1,0 +1,133 @@
+package webdav
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParsePropfindResponse(t *testing.T) {
+	xmlData := []byte(`<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
+  <d:response>
+    <d:href>/remote.php/dav/files/user/claude-sync/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:getlastmodified>Mon, 14 Apr 2025 10:00:00 GMT</d:getlastmodified>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/files/user/claude-sync/sessions/abc123.enc</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontentlength>4096</d:getcontentlength>
+        <d:getlastmodified>Mon, 14 Apr 2025 12:30:00 GMT</d:getlastmodified>
+        <d:getetag>"abc123def456"</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/files/user/claude-sync/settings.enc</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontentlength>512</d:getcontentlength>
+        <d:getlastmodified>Tue, 15 Apr 2025 08:00:00 GMT</d:getlastmodified>
+        <d:getetag>"def789ghi012"</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)
+
+	results, err := parsePropfindResponse(xmlData)
+	if err != nil {
+		t.Fatalf("parsePropfindResponse failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 responses, got %d", len(results))
+	}
+
+	if !results[0].IsCollection {
+		t.Error("first response should be a collection")
+	}
+
+	if results[1].IsCollection {
+		t.Error("second response should not be a collection")
+	}
+	if results[1].ContentLength != 4096 {
+		t.Errorf("expected content length 4096, got %d", results[1].ContentLength)
+	}
+	if results[1].ETag != "abc123def456" {
+		t.Errorf("expected etag abc123def456, got %q", results[1].ETag)
+	}
+	expectedTime := time.Date(2025, 4, 14, 12, 30, 0, 0, time.UTC)
+	if !results[1].LastModified.Equal(expectedTime) {
+		t.Errorf("expected last modified %v, got %v", expectedTime, results[1].LastModified)
+	}
+
+	if results[2].ContentLength != 512 {
+		t.Errorf("expected content length 512, got %d", results[2].ContentLength)
+	}
+}
+
+func TestParsePropfindResponseURLDecoding(t *testing.T) {
+	xmlData := []byte(`<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/user/claude-sync/path%20with%20spaces/file.enc</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontentlength>100</d:getcontentlength>
+        <d:getlastmodified>Mon, 14 Apr 2025 10:00:00 GMT</d:getlastmodified>
+        <d:getetag>"aaa"</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)
+
+	results, err := parsePropfindResponse(xmlData)
+	if err != nil {
+		t.Fatalf("parsePropfindResponse failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(results))
+	}
+
+	expected := "/remote.php/dav/files/user/claude-sync/path with spaces/file.enc"
+	if results[0].Href != expected {
+		t.Errorf("expected decoded href %q, got %q", expected, results[0].Href)
+	}
+}
+
+func TestParsePropfindResponseNon200Status(t *testing.T) {
+	xmlData := []byte(`<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/user/claude-sync/file.enc</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getcontentlength>999</d:getcontentlength>
+      </d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)
+
+	results, err := parsePropfindResponse(xmlData)
+	if err != nil {
+		t.Fatalf("parsePropfindResponse failed: %v", err)
+	}
+
+	if results[0].ContentLength != 0 {
+		t.Errorf("non-200 propstat should not populate content length, got %d", results[0].ContentLength)
+	}
+}

--- a/internal/storage/webdav/webdav.go
+++ b/internal/storage/webdav/webdav.go
@@ -1,0 +1,357 @@
+package webdav
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/tawanorg/claude-sync/internal/storage"
+)
+
+func init() {
+	storage.NewWebDAV = New
+}
+
+// Client implements the storage.Storage interface for WebDAV (Nextcloud, ownCloud, etc.)
+type Client struct {
+	baseURL    string
+	pathPrefix string
+	httpClient *http.Client
+	username   string
+	password   string
+}
+
+// New creates a new WebDAV storage client
+func New(cfg *storage.StorageConfig) (storage.Storage, error) {
+	baseURL := strings.TrimRight(cfg.WebDAVURL, "/")
+	if baseURL == "" {
+		return nil, fmt.Errorf("WebDAV URL is required")
+	}
+
+	prefix := strings.Trim(cfg.PathPrefix, "/")
+
+	return &Client{
+		baseURL:    baseURL,
+		pathPrefix: prefix,
+		username:   cfg.WebDAVUsername,
+		password:   cfg.WebDAVPassword,
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+func (c *Client) fullURL(key string) string {
+	if c.pathPrefix != "" {
+		return c.baseURL + "/" + c.pathPrefix + "/" + key
+	}
+	return c.baseURL + "/" + key
+}
+
+func (c *Client) collectionURL() string {
+	if c.pathPrefix != "" {
+		return c.baseURL + "/" + c.pathPrefix + "/"
+	}
+	return c.baseURL + "/"
+}
+
+func (c *Client) doRequest(ctx context.Context, method, url string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.username, c.password)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return c.httpClient.Do(req)
+}
+
+// Upload stores data with the given key, creating parent directories as needed.
+func (c *Client) Upload(ctx context.Context, key string, data []byte) error {
+	if err := c.ensureParentDirs(ctx, key); err != nil {
+		return fmt.Errorf("failed to create parent directories for %s: %w", key, err)
+	}
+
+	resp, err := c.doRequest(ctx, "PUT", c.fullURL(key), bytes.NewReader(data), map[string]string{
+		"Content-Type": "application/octet-stream",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to upload %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to upload %s: HTTP %d: %s", key, resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// Download retrieves data for the given key.
+func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
+	resp, err := c.doRequest(ctx, "GET", c.fullURL(key), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("object not found: %s", key)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download %s: HTTP %d", key, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", key, err)
+	}
+
+	return data, nil
+}
+
+// Delete removes the object with the given key.
+func (c *Client) Delete(ctx context.Context, key string) error {
+	resp, err := c.doRequest(ctx, "DELETE", c.fullURL(key), nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("failed to delete %s: HTTP %d", key, resp.StatusCode)
+	}
+
+	return nil
+}
+
+// DeleteBatch removes multiple objects sequentially.
+func (c *Client) DeleteBatch(ctx context.Context, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	for _, key := range keys {
+		if err := c.Delete(ctx, key); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// List returns all objects under the given prefix using PROPFIND.
+func (c *Client) List(ctx context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	url := c.collectionURL()
+	if prefix != "" {
+		url = c.collectionURL() + prefix
+		if !strings.HasSuffix(url, "/") {
+			url += "/"
+		}
+	}
+
+	propfindBody := `<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:getcontentlength/>
+    <d:getlastmodified/>
+    <d:getetag/>
+    <d:resourcetype/>
+  </d:prop>
+</d:propfind>`
+
+	resp, err := c.doRequest(ctx, "PROPFIND", url, strings.NewReader(propfindBody), map[string]string{
+		"Content-Type": "application/xml",
+		"Depth":        "infinity",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list objects: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if resp.StatusCode != 207 {
+		return nil, fmt.Errorf("failed to list objects: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PROPFIND response: %w", err)
+	}
+
+	responses, err := parsePropfindResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse PROPFIND response: %w", err)
+	}
+
+	collectionBase := c.collectionURL()
+	var objects []storage.ObjectInfo
+	for _, r := range responses {
+		if r.IsCollection {
+			continue
+		}
+
+		key := r.Href
+		if idx := strings.Index(key, c.pathPrefix+"/"); idx >= 0 {
+			key = key[idx+len(c.pathPrefix)+1:]
+		} else {
+			key = strings.TrimPrefix(key, collectionBase)
+		}
+		key = strings.TrimLeft(key, "/")
+
+		if key == "" {
+			continue
+		}
+
+		objects = append(objects, storage.ObjectInfo{
+			Key:          key,
+			Size:         r.ContentLength,
+			LastModified: r.LastModified,
+			ETag:         r.ETag,
+		})
+	}
+
+	return objects, nil
+}
+
+// Head returns metadata for the given key without downloading content.
+func (c *Client) Head(ctx context.Context, key string) (*storage.ObjectInfo, error) {
+	propfindBody := `<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:getcontentlength/>
+    <d:getlastmodified/>
+    <d:getetag/>
+    <d:resourcetype/>
+  </d:prop>
+</d:propfind>`
+
+	resp, err := c.doRequest(ctx, "PROPFIND", c.fullURL(key), strings.NewReader(propfindBody), map[string]string{
+		"Content-Type": "application/xml",
+		"Depth":        "0",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to head %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("object not found: %s", key)
+	}
+
+	if resp.StatusCode != 207 {
+		return nil, fmt.Errorf("failed to head %s: HTTP %d", key, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PROPFIND response: %w", err)
+	}
+
+	responses, err := parsePropfindResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse PROPFIND response: %w", err)
+	}
+
+	if len(responses) == 0 {
+		return nil, fmt.Errorf("object not found: %s", key)
+	}
+
+	r := responses[0]
+	return &storage.ObjectInfo{
+		Key:          key,
+		Size:         r.ContentLength,
+		LastModified: r.LastModified,
+		ETag:         r.ETag,
+	}, nil
+}
+
+// BucketExists checks if the configured path prefix exists and is accessible.
+// For WebDAV, the "bucket" concept maps to the path prefix directory.
+// Unlike S3/R2/GCS where buckets must be pre-created, WebDAV directories
+// can be created on the fly, so this auto-creates the path prefix if missing.
+func (c *Client) BucketExists(ctx context.Context) (bool, error) {
+	resp, err := c.doRequest(ctx, "PROPFIND", c.collectionURL(), strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:resourcetype/>
+  </d:prop>
+</d:propfind>`), map[string]string{
+		"Content-Type": "application/xml",
+		"Depth":        "0",
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to check WebDAV path: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 207 || resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return false, fmt.Errorf("authentication failed (HTTP %d) - check your username and app password", resp.StatusCode)
+	}
+
+	if resp.StatusCode == http.StatusNotFound && c.pathPrefix != "" {
+		// Auto-create the path prefix directory
+		mkResp, mkErr := c.doRequest(ctx, "MKCOL", c.collectionURL(), nil, nil)
+		if mkErr != nil {
+			return false, fmt.Errorf("failed to create WebDAV directory '%s': %w", c.pathPrefix, mkErr)
+		}
+		mkResp.Body.Close()
+		if mkResp.StatusCode == http.StatusCreated || mkResp.StatusCode == http.StatusMethodNotAllowed {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to create WebDAV directory '%s': HTTP %d", c.pathPrefix, mkResp.StatusCode)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("unexpected HTTP %d checking WebDAV path", resp.StatusCode)
+}
+
+// ensureParentDirs creates all parent collections for the given key via MKCOL.
+func (c *Client) ensureParentDirs(ctx context.Context, key string) error {
+	dir := path.Dir(key)
+	if dir == "." || dir == "/" || dir == "" {
+		return nil
+	}
+
+	parts := strings.Split(dir, "/")
+	current := ""
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if current == "" {
+			current = part
+		} else {
+			current = current + "/" + part
+		}
+
+		mkcolURL := c.collectionURL() + current + "/"
+		resp, err := c.doRequest(ctx, "MKCOL", mkcolURL, nil, nil)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		// 201 = created, 405 = already exists — both fine
+		if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusMethodNotAllowed && resp.StatusCode != http.StatusConflict {
+			if resp.StatusCode == http.StatusNotFound {
+				continue
+			}
+		}
+	}
+
+	return nil
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "r2",
     "s3",
     "gcs",
+    "webdav",
+    "nextcloud",
     "encryption"
   ],
   "author": "tawanorg",


### PR DESCRIPTION
## Summary

- Adds a new `webdav` storage provider enabling sync through self-hosted WebDAV servers (Nextcloud, ownCloud, etc.)
- Zero external dependencies — uses Go stdlib `net/http` and `encoding/xml` for all WebDAV operations (PUT, GET, DELETE, PROPFIND, MKCOL)
- Includes interactive setup wizard, CLI flags (`--webdav-url`, `--webdav-username`, `--webdav-password`, `--webdav-path-prefix`), and config validation

## Motivation

The existing providers (R2, S3, GCS) all require external cloud accounts. Many users already run Nextcloud or similar WebDAV servers and would prefer to keep their Claude Code session data self-hosted. WebDAV is a widely supported protocol that maps cleanly to the existing `Storage` interface.

## Implementation

| File | Change |
|---|---|
| `internal/storage/webdav/webdav.go` | `Storage` interface implementation via HTTP/WebDAV |
| `internal/storage/webdav/propfind.go` | XML parser for PROPFIND multistatus responses |
| `internal/storage/webdav/propfind_test.go` | Tests for XML parsing (collections, URL decoding, non-200 filtering) |
| `internal/storage/storage.go` | `ProviderWebDAV` constant, `NewWebDAV` factory var |
| `internal/storage/config.go` | WebDAV config fields, validation, bucket requirement skipped for WebDAV |
| `internal/storage/config_test.go` | 5 WebDAV validation test cases |
| `cmd/claude-sync/main.go` | Provider menu entry, CLI flags, setup wizard, side-effect import |

### Storage interface mapping

| Interface method | WebDAV operation |
|---|---|
| `Upload` | `PUT` with auto `MKCOL` for parent dirs |
| `Download` | `GET` |
| `Delete` / `DeleteBatch` | `DELETE` (sequential for batch) |
| `List` | `PROPFIND` depth-infinity, filters out collections |
| `Head` | `PROPFIND` depth-0 |
| `BucketExists` | `PROPFIND` depth-0 on root path prefix |

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New PROPFIND parser tests pass (collections, URL-encoded paths, non-200 propstat)
- [x] New config validation tests pass (valid config, missing URL/username/password, bucket not required)
- [x] Binary builds and `--help` shows WebDAV provider
- [x] End-to-end: `claude-sync init --provider webdav` → push → pull on second device

🤖 Generated with [Claude Code](https://claude.com/claude-code)