### PR TITLE
feat: sync plans and tasks directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ claude-sync pull
 | Path | Content |
 |------|---------|
 | `~/.claude/projects/` | Session files, auto-memory |
+| `~/.claude/plans/` | Implementation plans from plan mode |
+| `~/.claude/tasks/` | Task tracking state |
 | `~/.claude/history.jsonl` | Command history |
 | `~/.claude/agents/` | Custom agents |
 | `~/.claude/skills/` | Custom skills |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,8 @@ var SyncPaths = []string{
 	"skills",
 	"plugins",
 	"projects",
+	"plans",
+	"tasks",
 	"history.jsonl",
 	"rules",
 }


### PR DESCRIPTION
## Summary

- Add `~/.claude/plans/` and `~/.claude/tasks/` to `SyncPaths`
- Update README "What Gets Synced" table

## Motivation

Claude Code's plan mode (`/plan`) writes implementation plans to `~/.claude/plans/` and tracks task state in `~/.claude/tasks/`. These aren't currently synced, so switching devices mid-plan loses context. Both directories are small and meaningful for cross-device continuity.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `claude-sync push` includes files from `plans/` and `tasks/`
- [x] `claude-sync pull` restores them on another device

🤖 Generated with [Claude Code](https://claude.com/claude-code)