### PR TITLE
docs: silence background job output in shell integration snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,18 @@ Add to `~/.zshrc` or `~/.bashrc`:
 ```bash
 # Auto-pull on shell start
 if command -v claude-sync &> /dev/null; then
-  claude-sync pull -q &
+  # Run in a subshell so the job is detached from the parent shell's
+  # job table — avoids interactive `[1] 12345` / `[1] + done` noise.
+  (claude-sync pull -q &) >/dev/null 2>&1
 fi
 
 # Auto-push on shell exit
 trap 'claude-sync push -q' EXIT
 ```
+
+> **Note:** The subshell wrapper `(cmd &)` prevents zsh/bash from printing job control
+> messages (`[1] 12345` on start and `[1] + done cmd` on completion) every time you open
+> a terminal. A plain `claude-sync pull -q &` works but produces noisy shell prompts.
 
 ## Pulling with Existing Files
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -527,7 +527,9 @@ For automatic syncing, add to your shell profile:
 
 # Auto-pull on shell start (background, quiet)
 if command -v claude-sync &> /dev/null; then
-  claude-sync pull -q &
+  # Subshell detaches the job from the parent shell's job table —
+  # avoids `[1] 12345` / `[1] + done` noise on every terminal open.
+  (claude-sync pull -q &) >/dev/null 2>&1
 fi
 
 # Auto-push on shell exit (quiet)
@@ -537,6 +539,8 @@ trap 'claude-sync push -q' EXIT
 This ensures:
 - Fresh sessions are pulled when you start a terminal
 - Local changes are pushed when you close a terminal
+
+> See the [README's Shell Integration section](../README.md#shell-integration) for the rationale behind the `(cmd &)` subshell wrapper.
 
 ---
 


### PR DESCRIPTION
## Summary

Tiny README tweak. The current shell integration snippet recommends:

```bash
if command -v claude-sync &> /dev/null; then
  claude-sync pull -q &
fi
```

In interactive zsh/bash, the trailing `&` causes the shell to print job-control messages every time a terminal is opened:

```
Last login: Mon May 11 21:18:11 on ttys009
[2] 17215
❯
[2]  + done       claude-sync pull -q
❯
```

These two extra lines per shell start are harmless but visually noisy — especially with a prompt that renders a separator line.

## Fix

Wrap the background call in a subshell so the job is detached from the parent shell's job table:

```bash
(claude-sync pull -q &) >/dev/null 2>&1
```

The pull still runs in the background; the parent shell just never tracks it, so no `[N] PID` start line and no `done` completion line are printed. Redirecting stdout/stderr also keeps any stray output from leaking into the prompt.

Verified locally on macOS zsh 5.9 — terminal opens clean, `claude-sync pull -q` still runs (visible in `ps`).

## Test plan

- [ ] Open a new interactive zsh/bash shell with the updated snippet — no `[N] PID` or `+ done` lines appear
- [ ] Confirm `claude-sync pull` still executes (`ps aux | grep claude-sync` during shell start, or check sync state after)