### PR TITLE
feat: normalize project paths for cross-device sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,26 +155,35 @@ claude-sync pull
 | `~/.claude/settings.local.json` | Local settings |
 | `~/.claude/CLAUDE.md` | Global instructions |
 
-## Limitations
+## Cross-Device Path Mapping
 
-### Path-Based Session Indexing
-
-Claude Code indexes project sessions by **absolute filesystem path**. This tool syncs `~/.claude/projects/` but does not perform path remapping, which means:
+Claude Code indexes project sessions by **absolute filesystem path**:
 
 ```
-/Users/alice/Projects/my-app → ~/.claude/projects/-Users-alice-Projects-my-app/
-/Users/bob/code/my-app       → ~/.claude/projects/-Users-bob-code-my-app/
+/Users/alice/my-app → ~/.claude/projects/-Users-alice-my-app/
+/Users/bob/my-app   → ~/.claude/projects/-Users-bob-my-app/
 ```
 
-These are treated as **completely different projects** by Claude Code. After syncing, `claude --resume` on machine2 won't find sessions from machine1 if the project paths differ.
+Synced verbatim, those would be **different projects** and `claude --resume` on the second machine would never find the first machine's sessions. claude-sync solves this by translating paths during sync:
 
-**Workaround:** Use consistent absolute paths across all devices. For example:
+- **Home directories are mapped automatically.** Sessions are stored remotely under a portable `${HOME}` token (in both remote keys and transcript content), then rewritten to each device's real home on pull. Different usernames across machines just work.
+- **Other layout differences are configurable.** If one machine keeps projects in `~/work` and another in `~/Projects`, point both at the same token in `~/.claude-sync/config.yaml`:
 
-- Always clone repos to `~/Projects/` on every machine
-- Use symlinks to maintain the same path structure
-- Consider a standardized home directory structure
+  ```yaml
+  # machine 1
+  path_map:
+    ~/work: WORK
+  ```
 
-If you follow a consistent path convention, sessions will sync and resume correctly across devices.
+  ```yaml
+  # machine 2
+  path_map:
+    ~/Projects: WORK
+  ```
+
+  Sessions under either directory sync to the shared `${WORK}` namespace and resume correctly on both machines.
+
+**Upgrading from an older version?** Run `claude-sync migrate` once on each device to convert existing remote data to portable keys. Paths the current device doesn't own are left for the other device's migrate run.
 
 ## Commands
 
@@ -186,6 +195,7 @@ claude-sync status      # Show pending local changes
 claude-sync diff        # Show differences between local and remote
 claude-sync conflicts   # List and resolve conflicts
 claude-sync reset       # Reset configuration (forgot passphrase)
+claude-sync migrate     # Convert legacy remote keys to portable path-mapped keys
 claude-sync update      # Update to latest version
 claude-sync changelog   # Show release history
 claude-sync --help      # Show all commands

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -63,6 +63,7 @@ func main() {
 		diffCmd(),
 		conflictsCmd(),
 		resetCmd(),
+		migrateCmd(),
 		updateCmd(),
 		changelogCmd(),
 		mcpCmd(),
@@ -1536,6 +1537,93 @@ Examples:
 	cmd.Flags().BoolVar(&clearRemote, "remote", false, "Delete all files from cloud storage bucket")
 	cmd.Flags().BoolVar(&clearLocal, "local", false, "Clear local sync state")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func migrateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Rewrite legacy remote keys to portable path-mapped keys",
+		Long: `Re-upload this device's project files under portable, path-mapped remote
+keys and delete the legacy machine-specific keys.
+
+Older versions stored project sessions under keys derived from this machine's
+absolute paths (e.g. projects/-Users-alice-my-app/...), so sessions pulled on
+a device with a different username or layout were not resumable. New pushes
+use portable tokens (e.g. projects/${HOME}-my-app/...); migrate converts
+existing remote data in place.
+
+Run this once on every device. Keys owned by another device are left for that
+device's migrate run and reported as "left for other devices".`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			syncer, err := sync.NewSyncer(cfg, quiet)
+			if err != nil {
+				return err
+			}
+
+			if !quiet {
+				syncer.SetProgressFunc(func(event sync.ProgressEvent) {
+					if event.Error != nil {
+						fmt.Printf("\r%s✗%s %s: %v\n", colorYellow, colorReset, event.Path, event.Error)
+						return
+					}
+					if event.Action == "upload" && !event.Complete {
+						progress := fmt.Sprintf("[%d/%d]", event.Current, event.Total)
+						shortPath := util.TruncatePath(event.Path, 50)
+						fmt.Printf("\r%s↻%s %s%s%s %s%s",
+							colorCyan, colorReset,
+							colorDim, progress, colorReset,
+							shortPath,
+							strings.Repeat(" ", 10))
+					}
+				})
+				fmt.Printf("%s⋯%s Scanning remote for legacy keys...\n", colorDim, colorReset)
+			}
+
+			result, err := syncer.MigratePaths(context.Background())
+			if err != nil {
+				return err
+			}
+
+			if !quiet {
+				fmt.Println()
+				if len(result.Migrated) == 0 && len(result.Foreign) == 0 && len(result.Errors) == 0 {
+					fmt.Printf("%s✓%s Nothing to migrate\n", colorGreen, colorReset)
+					return nil
+				}
+
+				var parts []string
+				if len(result.Migrated) > 0 {
+					parts = append(parts, fmt.Sprintf("%s%d migrated%s", colorGreen, len(result.Migrated), colorReset))
+				}
+				if len(result.Foreign) > 0 {
+					parts = append(parts, fmt.Sprintf("%s%d left for other devices%s", colorDim, len(result.Foreign), colorReset))
+				}
+				if len(result.Errors) > 0 {
+					parts = append(parts, fmt.Sprintf("%s%d failed%s", colorYellow, len(result.Errors), colorReset))
+				}
+				fmt.Printf("%s✓%s Migration complete: %s\n", colorGreen, colorReset, strings.Join(parts, ", "))
+
+				if len(result.Foreign) > 0 {
+					fmt.Printf("\n%sRun 'claude-sync migrate' on your other devices to convert the remaining keys.%s\n", colorDim, colorReset)
+				}
+				if len(result.Errors) > 0 {
+					fmt.Printf("\n%sErrors:%s\n", colorYellow, colorReset)
+					for _, e := range result.Errors {
+						fmt.Printf("  %s•%s %v\n", colorYellow, colorReset, e)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
 
 	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,17 @@ type Config struct {
 	// MCPSync enables syncing MCP server configs from ~/.claude.json
 	MCPSync bool `yaml:"mcp_sync,omitempty"`
 
+	// PathMap maps local directory prefixes to shared token names so project
+	// sessions stay resumable across devices with different layouts.
+	// The home directory is always mapped (token HOME); add entries here when
+	// project roots differ beyond that, e.g.:
+	//   path_map:
+	//     ~/work: WORK        # this device keeps projects in ~/work
+	// with the other device mapping its own location to the same token:
+	//   path_map:
+	//     ~/Projects: WORK
+	PathMap map[string]string `yaml:"path_map,omitempty"`
+
 	// ClaudeDirOverride allows overriding the default ~/.claude path (for testing)
 	ClaudeDirOverride string `yaml:"-"`
 
@@ -124,6 +135,19 @@ func Load() (*Config, error) {
 	if cfg.EncryptionKey != "" && cfg.EncryptionKey[0] == '~' {
 		home, _ := os.UserHomeDir()
 		cfg.EncryptionKey = filepath.Join(home, cfg.EncryptionKey[1:])
+	}
+
+	// Expand ~ in path_map keys
+	if len(cfg.PathMap) > 0 {
+		home, _ := os.UserHomeDir()
+		expanded := make(map[string]string, len(cfg.PathMap))
+		for p, name := range cfg.PathMap {
+			if p != "" && p[0] == '~' {
+				p = filepath.Join(home, p[1:])
+			}
+			expanded[p] = name
+		}
+		cfg.PathMap = expanded
 	}
 
 	// Set default endpoint for Cloudflare R2

--- a/internal/sync/migrate.go
+++ b/internal/sync/migrate.go
@@ -1,0 +1,81 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MigrateResult describes the outcome of migrating legacy remote keys to
+// portable (path-normalized) keys.
+type MigrateResult struct {
+	Migrated []string // local paths re-uploaded under normalized keys
+	Foreign  []string // legacy keys owned by another device (run migrate there)
+	Errors   []error
+}
+
+// MigratePaths rewrites this device's legacy remote project keys to the
+// portable token form: each file is re-uploaded under its normalized key
+// (with content normalization applied) and the legacy key is deleted.
+//
+// Keys that don't match any of this device's path mappings — typically
+// projects pushed from another machine — are left untouched and reported in
+// Foreign; running migrate on that machine completes the migration.
+func (s *Syncer) MigratePaths(ctx context.Context) (*MigrateResult, error) {
+	result := &MigrateResult{}
+
+	remoteObjects, err := s.storage.List(ctx, "projects/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remote objects: %w", err)
+	}
+
+	var legacyKeys []string
+	for _, obj := range remoteObjects {
+		if !strings.HasSuffix(obj.Key, ".age") {
+			continue
+		}
+		raw := strings.TrimSuffix(obj.Key, ".age")
+		if seg, _, ok := splitProjectsPath(raw); !ok || strings.HasPrefix(seg, tokenPrefix) {
+			continue // already normalized
+		}
+		if s.isExcluded(raw) {
+			continue
+		}
+		normalized := s.paths.NormalizeRelPath(raw)
+		if normalized == raw {
+			// Not under any of this device's mapped prefixes
+			result.Foreign = append(result.Foreign, raw)
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(s.claudeDir, raw)); err != nil {
+			// We can't re-encrypt content we don't have locally
+			result.Foreign = append(result.Foreign, raw)
+			continue
+		}
+		legacyKeys = append(legacyKeys, raw)
+	}
+
+	total := len(legacyKeys)
+	for i, raw := range legacyKeys {
+		s.progress(ProgressEvent{Action: "upload", Path: raw, Current: i + 1, Total: total})
+		if err := s.uploadFile(ctx, raw); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", raw, err))
+			continue
+		}
+		if err := s.storage.Delete(ctx, raw+".age"); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("delete legacy %s: %w", raw, err))
+			continue
+		}
+		result.Migrated = append(result.Migrated, raw)
+	}
+
+	if total > 0 {
+		if err := s.state.Save(); err != nil {
+			return result, fmt.Errorf("failed to save state: %w", err)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/sync/paths.go
+++ b/internal/sync/paths.go
@@ -1,0 +1,214 @@
+package sync
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// PathMapper translates machine-specific project paths to portable tokens on
+// push and back to local paths on pull, so sessions started on one device are
+// resumable on another even when home directories or project layouts differ.
+//
+// Claude Code stores sessions under ~/.claude/projects/<encoded-cwd>/ where
+// <encoded-cwd> is the working directory with every non-alphanumeric character
+// replaced by "-" (e.g. /Users/alice/my-app -> -Users-alice-my-app). Because
+// the encoding is keyed to the absolute path, a transcript synced verbatim to
+// a machine with a different username or layout lands in a directory that
+// `claude --resume` never looks at.
+//
+// The mapper rewrites two things:
+//   - remote keys:   projects/-Users-alice-my-app/... -> projects/${HOME}-my-app/...
+//   - file content:  /Users/alice -> ${HOME} (cwd fields, tool paths)
+//
+// HOME is always mapped. Additional prefixes (e.g. ~/work on one machine,
+// ~/Projects on another) can be mapped via the path_map config, with both
+// machines pointing their own local path at the same token name.
+type PathMapper struct {
+	// mappings ordered longest local path first so the most specific prefix wins
+	mappings []pathMapping
+}
+
+type pathMapping struct {
+	name      string // token name, e.g. "HOME", "WORK"
+	localPath string // absolute local path, no trailing slash
+	encLocal  string // localPath in Claude Code's directory encoding
+	normRe    *regexp.Regexp
+	normRepl  []byte // replacement template: token ($-escaped) + boundary group
+}
+
+var pathTokenNameRe = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// NewPathMapper builds a mapper for this device. userMap maps local absolute
+// paths (already ~-expanded) to token names shared across devices.
+func NewPathMapper(homeDir string, userMap map[string]string) (*PathMapper, error) {
+	m := &PathMapper{}
+
+	add := func(name, localPath string) error {
+		localPath = strings.TrimRight(localPath, "/")
+		if localPath == "" {
+			return nil
+		}
+		if !pathTokenNameRe.MatchString(name) {
+			return fmt.Errorf("invalid path_map token %q: use uppercase letters, digits, underscores (e.g. WORK)", name)
+		}
+		// Boundary-aware: only replace the path when it is not followed by a
+		// name character, so /Users/merv never matches inside /Users/mervynlally.
+		re := regexp.MustCompile(regexp.QuoteMeta(localPath) + `([^A-Za-z0-9_.-]|$)`)
+		m.mappings = append(m.mappings, pathMapping{
+			name:      name,
+			localPath: localPath,
+			encLocal:  EncodeClaudePath(localPath),
+			normRe:    re,
+			// "$$" = literal "$" in a regexp replacement template; without it
+			// "${HOME}" would itself be read as a group reference
+			normRepl: []byte("$${" + name + "}${1}"),
+		})
+		return nil
+	}
+
+	for localPath, name := range userMap {
+		if strings.EqualFold(name, "HOME") {
+			return nil, fmt.Errorf("path_map token HOME is reserved (the home directory is mapped automatically)")
+		}
+		if err := add(name, localPath); err != nil {
+			return nil, err
+		}
+	}
+	if homeDir != "" {
+		if err := add("HOME", homeDir); err != nil {
+			return nil, err
+		}
+	}
+
+	// Longest local path first so ~/work maps to its own token before ~ does.
+	sort.SliceStable(m.mappings, func(i, j int) bool {
+		return len(m.mappings[i].localPath) > len(m.mappings[j].localPath)
+	})
+
+	return m, nil
+}
+
+// EncodeClaudePath applies Claude Code's project directory encoding: every
+// character outside [A-Za-z0-9] becomes "-".
+func EncodeClaudePath(p string) string {
+	var b strings.Builder
+	b.Grow(len(p))
+	for _, r := range p {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+// Tokens use the ${NAME} form in both remote keys and file content. This
+// matches the format already written to existing buckets; note that a literal
+// "${HOME}" in transcript content (e.g. a quoted shell snippet) is therefore
+// indistinguishable from a normalized path and resolves to the local home
+// directory on pull.
+func pathToken(name string) string { return "${" + name + "}" }
+
+const tokenPrefix = "${"
+
+// splitProjectsPath splits "projects/<seg>/rest" into seg and "/rest".
+// ok is false for paths not under projects/.
+func splitProjectsPath(relPath string) (seg, rest string, ok bool) {
+	const prefix = "projects/"
+	if !strings.HasPrefix(relPath, prefix) {
+		return "", "", false
+	}
+	remainder := relPath[len(prefix):]
+	if i := strings.IndexByte(remainder, '/'); i >= 0 {
+		return remainder[:i], remainder[i:], true
+	}
+	return remainder, "", true
+}
+
+// NormalizeRelPath rewrites a local relative path to its portable remote form.
+// Only project directory segments are affected; everything else is unchanged.
+// A nil mapper performs no translation (legacy behavior).
+func (m *PathMapper) NormalizeRelPath(relPath string) string {
+	if m == nil {
+		return relPath
+	}
+	seg, rest, ok := splitProjectsPath(relPath)
+	if !ok || strings.HasPrefix(seg, tokenPrefix) {
+		return relPath
+	}
+	for _, mp := range m.mappings {
+		if seg == mp.encLocal || strings.HasPrefix(seg, mp.encLocal+"-") {
+			return "projects/" + pathToken(mp.name) + seg[len(mp.encLocal):] + rest
+		}
+	}
+	return relPath
+}
+
+// ResolveRelPath rewrites a portable remote path back to a local relative
+// path. ok is false when the path uses a token this device has no mapping
+// for (the caller should skip the file and tell the user to extend path_map).
+func (m *PathMapper) ResolveRelPath(relPath string) (string, bool) {
+	if m == nil {
+		return relPath, true
+	}
+	seg, rest, isProject := splitProjectsPath(relPath)
+	if !isProject || !strings.HasPrefix(seg, tokenPrefix) {
+		return relPath, true
+	}
+	for _, mp := range m.mappings {
+		token := pathToken(mp.name)
+		if strings.HasPrefix(seg, token) {
+			return "projects/" + mp.encLocal + seg[len(token):] + rest, true
+		}
+	}
+	return relPath, false
+}
+
+// NormalizeContent replaces this device's mapped path prefixes with portable
+// tokens in file content. Replacement is boundary-aware so one user's home
+// path never matches inside a longer username.
+func (m *PathMapper) NormalizeContent(data []byte) []byte {
+	if m == nil {
+		return data
+	}
+	for _, mp := range m.mappings {
+		data = mp.normRe.ReplaceAll(data, mp.normRepl)
+	}
+	return data
+}
+
+// ResolveContent replaces portable tokens with this device's local paths.
+func (m *PathMapper) ResolveContent(data []byte) []byte {
+	if m == nil {
+		return data
+	}
+	for _, mp := range m.mappings {
+		data = bytes.ReplaceAll(data, []byte(pathToken(mp.name)), []byte(mp.localPath))
+	}
+	return data
+}
+
+// IsPortableContentPath reports whether content path translation applies to
+// this relative path: text formats under projects/ plus the prompt history.
+// Conflict copies (path.conflict.<timestamp>) inherit the base path's rule.
+func IsPortableContentPath(relPath string) bool {
+	if i := strings.Index(relPath, ".conflict."); i >= 0 {
+		relPath = relPath[:i]
+	}
+	if relPath == "history.jsonl" {
+		return true
+	}
+	if !strings.HasPrefix(relPath, "projects/") {
+		return false
+	}
+	switch path.Ext(relPath) {
+	case ".jsonl", ".json", ".md", ".txt":
+		return true
+	}
+	return false
+}

--- a/internal/sync/paths_test.go
+++ b/internal/sync/paths_test.go
@@ -1,0 +1,299 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func mustMapper(t *testing.T, home string, userMap map[string]string) *PathMapper {
+	t.Helper()
+	m, err := NewPathMapper(home, userMap)
+	if err != nil {
+		t.Fatalf("NewPathMapper: %v", err)
+	}
+	return m
+}
+
+func TestEncodeClaudePath(t *testing.T) {
+	cases := map[string]string{
+		"/Users/alice/my-app":      "-Users-alice-my-app",
+		"/Users/merv/.config/brc":  "-Users-merv--config-brc",
+		"C:\\Users\\merv\\app_1":   "C--Users-merv-app-1",
+		"/home/bob/Projects/RedXY": "-home-bob-Projects-RedXY",
+	}
+	for in, want := range cases {
+		if got := EncodeClaudePath(in); got != want {
+			t.Errorf("EncodeClaudePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeResolveRelPath(t *testing.T) {
+	alice := mustMapper(t, "/Users/alice", map[string]string{"/Users/alice/work": "WORK"})
+	bob := mustMapper(t, "/Users/bob", map[string]string{"/Users/bob/Projects": "WORK"})
+
+	cases := []struct {
+		local      string // on alice's machine
+		normalized string
+		onBob      string
+	}{
+		{
+			"projects/-Users-alice-my-app/sess.jsonl",
+			"projects/${HOME}-my-app/sess.jsonl",
+			"projects/-Users-bob-my-app/sess.jsonl",
+		},
+		{
+			// most specific mapping wins over HOME
+			"projects/-Users-alice-work-api/sess.jsonl",
+			"projects/${WORK}-api/sess.jsonl",
+			"projects/-Users-bob-Projects-api/sess.jsonl",
+		},
+		{
+			// exact project at the mapped root
+			"projects/-Users-alice-work/sess.jsonl",
+			"projects/${WORK}/sess.jsonl",
+			"projects/-Users-bob-Projects/sess.jsonl",
+		},
+		{
+			// non-projects paths untouched
+			"settings.json",
+			"settings.json",
+			"settings.json",
+		},
+		{
+			// foreign machine's directory left alone
+			"projects/-Users-zed-app/sess.jsonl",
+			"projects/-Users-zed-app/sess.jsonl",
+			"projects/-Users-zed-app/sess.jsonl",
+		},
+	}
+
+	for _, c := range cases {
+		norm := alice.NormalizeRelPath(c.local)
+		if norm != c.normalized {
+			t.Errorf("NormalizeRelPath(%q) = %q, want %q", c.local, norm, c.normalized)
+			continue
+		}
+		resolved, ok := bob.ResolveRelPath(norm)
+		if !ok {
+			t.Errorf("ResolveRelPath(%q): unexpectedly unresolvable", norm)
+			continue
+		}
+		if resolved != c.onBob {
+			t.Errorf("ResolveRelPath(%q) = %q, want %q", norm, resolved, c.onBob)
+		}
+	}
+}
+
+func TestNormalizeRelPathUsernamePrefixTrap(t *testing.T) {
+	// /Users/merv must not match inside /Users/mervynlally's encoded dirs
+	merv := mustMapper(t, "/Users/merv", nil)
+	in := "projects/-Users-mervynlally-nexura/sess.jsonl"
+	if got := merv.NormalizeRelPath(in); got != in {
+		t.Errorf("NormalizeRelPath(%q) = %q, want unchanged", in, got)
+	}
+	// but its own dirs do match
+	own := "projects/-Users-merv-nexura/sess.jsonl"
+	if got := merv.NormalizeRelPath(own); got != "projects/${HOME}-nexura/sess.jsonl" {
+		t.Errorf("NormalizeRelPath(%q) = %q", own, got)
+	}
+}
+
+func TestResolveRelPathUnknownToken(t *testing.T) {
+	m := mustMapper(t, "/Users/bob", nil)
+	if _, ok := m.ResolveRelPath("projects/${WORK}-api/sess.jsonl"); ok {
+		t.Error("expected unknown token to be unresolvable")
+	}
+}
+
+func TestContentRoundTrip(t *testing.T) {
+	alice := mustMapper(t, "/Users/merv", nil)
+	bob := mustMapper(t, "/Users/mervynlally", nil)
+
+	in := []byte(`{"cwd":"/Users/merv/nexura","note":"see /Users/mervynlally/nexura and /Users/merv"}`)
+	norm := alice.NormalizeContent(in)
+
+	want := `{"cwd":"${HOME}/nexura","note":"see /Users/mervynlally/nexura and ${HOME}"}`
+	if string(norm) != want {
+		t.Fatalf("NormalizeContent = %s, want %s", norm, want)
+	}
+
+	resolved := bob.ResolveContent(norm)
+	wantResolved := `{"cwd":"/Users/mervynlally/nexura","note":"see /Users/mervynlally/nexura and /Users/mervynlally"}`
+	if string(resolved) != wantResolved {
+		t.Fatalf("ResolveContent = %s, want %s", resolved, wantResolved)
+	}
+}
+
+func TestContentBoundaries(t *testing.T) {
+	m := mustMapper(t, "/Users/merv", nil)
+
+	// dotted and dashed continuations are part of a different name, not a boundary
+	for _, s := range []string{"/Users/merv.bak/x", "/Users/merv-old/x", "/Users/mervyn/x"} {
+		if got := m.NormalizeContent([]byte(s)); string(got) != s {
+			t.Errorf("NormalizeContent(%q) = %q, should be untouched", s, got)
+		}
+	}
+	// end of data is a boundary
+	if got := m.NormalizeContent([]byte("/Users/merv")); string(got) != "${HOME}" {
+		t.Errorf("NormalizeContent at EOF = %q", got)
+	}
+}
+
+func TestPathMapperValidation(t *testing.T) {
+	if _, err := NewPathMapper("/Users/a", map[string]string{"/x": "home"}); err == nil {
+		t.Error("expected reserved-name error for HOME (case-insensitive)")
+	}
+	if _, err := NewPathMapper("/Users/a", map[string]string{"/x": "my-work"}); err == nil {
+		t.Error("expected invalid token name error")
+	}
+	if _, err := NewPathMapper("/Users/a", map[string]string{"/x": "WORK_2"}); err != nil {
+		t.Errorf("valid token rejected: %v", err)
+	}
+}
+
+func TestIsPortableContentPath(t *testing.T) {
+	cases := map[string]bool{
+		"history.jsonl":                                           true,
+		"projects/-Users-a-x/sess.jsonl":                          true,
+		"projects/-Users-a-x/memory/notes.md":                     true,
+		"projects/-Users-a-x/sess.jsonl.conflict.20260610-120000": true,
+		"projects/-Users-a-x/img.png":                             false,
+		"settings.json":                                           false,
+		"agents/foo.md":                                           false,
+	}
+	for in, want := range cases {
+		if got := IsPortableContentPath(in); got != want {
+			t.Errorf("IsPortableContentPath(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestCrossDeviceSessionSync simulates two devices with different usernames
+// sharing one bucket: a session pushed from alice's machine must land on
+// bob's machine under bob's encoded project directory with rewritten content.
+func TestCrossDeviceSessionSync(t *testing.T) {
+	syncerA, store, claudeDirA := testSyncer(t)
+	syncerA.paths = mustMapper(t, "/Users/alice", nil)
+
+	sessDir := filepath.Join(claudeDirA, "projects", "-Users-alice-my-app")
+	if err := os.MkdirAll(sessDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"cwd":"/Users/alice/my-app","type":"user"}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessDir, "sess.jsonl"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := syncerA.Push(context.Background()); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	wantKey := "projects/${HOME}-my-app/sess.jsonl.age"
+	if _, err := store.Download(context.Background(), wantKey); err != nil {
+		t.Fatalf("expected normalized remote key %s: %v", wantKey, err)
+	}
+
+	// Second device: same bucket and key, different username
+	tmpB := t.TempDir()
+	claudeDirB := filepath.Join(tmpB, ".claude")
+	if err := os.MkdirAll(claudeDirB, 0755); err != nil {
+		t.Fatal(err)
+	}
+	stateB, err := LoadStateFromDir(tmpB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncerB := NewSyncerWith(syncerA.cfg, store, syncerA.encryptor, stateB, claudeDirB, true)
+	syncerB.paths = mustMapper(t, "/Users/bob", nil)
+
+	result, err := syncerB.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("pull errors: %v", result.Errors)
+	}
+
+	localPath := filepath.Join(claudeDirB, "projects", "-Users-bob-my-app", "sess.jsonl")
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("expected session under bob's project dir: %v", err)
+	}
+	want := `{"cwd":"/Users/bob/my-app","type":"user"}` + "\n"
+	if string(data) != want {
+		t.Errorf("content = %s, want %s", data, want)
+	}
+
+	info, _ := os.Stat(localPath)
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("downloaded file mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestMigratePaths(t *testing.T) {
+	syncer, store, claudeDir := testSyncer(t)
+	ctx := context.Background()
+
+	// Create the local session file
+	sessDir := filepath.Join(claudeDir, "projects", "-Users-alice-my-app")
+	if err := os.MkdirAll(sessDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	relPath := "projects/-Users-alice-my-app/sess.jsonl"
+	if err := os.WriteFile(filepath.Join(claudeDir, relPath), []byte(`{"cwd":"/Users/alice/my-app"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push under legacy (identity) keys, as an old version would have
+	syncer.paths = mustMapper(t, "/nonexistent-home-zz", nil)
+	if _, err := syncer.Push(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Download(ctx, relPath+".age"); err != nil {
+		t.Fatalf("legacy key missing after push: %v", err)
+	}
+
+	// A key owned by another device: no local copy here
+	if err := store.Upload(ctx, "projects/-Users-zed-other/x.jsonl.age", []byte("opaque")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upgrade: mapper now knows this machine is alice's
+	syncer.paths = mustMapper(t, "/Users/alice", nil)
+
+	result, err := syncer.MigratePaths(ctx)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("migrate errors: %v", result.Errors)
+	}
+	if len(result.Migrated) != 1 || result.Migrated[0] != relPath {
+		t.Errorf("Migrated = %v, want [%s]", result.Migrated, relPath)
+	}
+	if len(result.Foreign) != 1 || result.Foreign[0] != "projects/-Users-zed-other/x.jsonl" {
+		t.Errorf("Foreign = %v", result.Foreign)
+	}
+
+	if _, err := store.Download(ctx, relPath+".age"); err == nil {
+		t.Error("legacy key still present after migrate")
+	}
+	if _, err := store.Download(ctx, "projects/${HOME}-my-app/sess.jsonl.age"); err != nil {
+		t.Errorf("normalized key missing after migrate: %v", err)
+	}
+	if _, err := store.Download(ctx, "projects/-Users-zed-other/x.jsonl.age"); err != nil {
+		t.Errorf("foreign key should be untouched: %v", err)
+	}
+
+	// Second run is a no-op for this device
+	result2, err := syncer.MigratePaths(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result2.Migrated) != 0 {
+		t.Errorf("second migrate should migrate nothing, got %v", result2.Migrated)
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -34,6 +34,7 @@ type Syncer struct {
 	quiet      bool
 	onProgress ProgressFunc
 	cfg        *config.Config
+	paths      *PathMapper
 }
 
 type SyncResult struct {
@@ -85,6 +86,12 @@ func NewSyncer(cfg *config.Config, quiet bool) (*Syncer, error) {
 		claudeDir = cfg.ClaudeDirOverride
 	}
 
+	homeDir, _ := os.UserHomeDir()
+	mapper, err := NewPathMapper(homeDir, cfg.PathMap)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Syncer{
 		storage:   store,
 		encryptor: enc,
@@ -92,11 +99,14 @@ func NewSyncer(cfg *config.Config, quiet bool) (*Syncer, error) {
 		claudeDir: claudeDir,
 		quiet:     quiet,
 		cfg:       cfg,
+		paths:     mapper,
 	}, nil
 }
 
 // NewSyncerWith creates a Syncer with pre-built dependencies (for testing).
 func NewSyncerWith(cfg *config.Config, store storage.Storage, enc *crypto.Encryptor, state *SyncState, claudeDir string, quiet bool) *Syncer {
+	homeDir, _ := os.UserHomeDir()
+	mapper, _ := NewPathMapper(homeDir, cfg.PathMap)
 	return &Syncer{
 		storage:   store,
 		encryptor: enc,
@@ -104,6 +114,7 @@ func NewSyncerWith(cfg *config.Config, store storage.Storage, enc *crypto.Encryp
 		claudeDir: claudeDir,
 		quiet:     quiet,
 		cfg:       cfg,
+		paths:     mapper,
 	}
 }
 
@@ -241,22 +252,10 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 	}
 
 	// Build remote file map
-	remoteFiles := make(map[string]storage.ObjectInfo)
-	for _, obj := range remoteObjects {
-		// Skip non-encrypted files
-		if !strings.HasSuffix(obj.Key, ".age") {
-			continue
-		}
-		localPath := s.localPath(obj.Key)
-		// Skip external files (handled by MCP sync)
-		if strings.HasPrefix(localPath, "_external/") {
-			continue
-		}
-		// Skip excluded paths
-		if s.isExcluded(localPath) {
-			continue
-		}
-		remoteFiles[localPath] = obj
+	remoteFiles, skipped := s.buildRemoteMap(remoteObjects)
+	for _, key := range skipped {
+		result.Errors = append(result.Errors,
+			fmt.Errorf("%s: unknown path token; add the matching path_map entry on this device", key))
 	}
 
 	// Get current local files
@@ -376,6 +375,11 @@ func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
+	// Replace machine-specific paths with portable tokens in session content
+	if IsPortableContentPath(relativePath) {
+		data = s.paths.NormalizeContent(data)
+	}
+
 	// Compress
 	compressed, err := gzipCompress(data)
 	if err != nil {
@@ -424,15 +428,25 @@ func (s *Syncer) downloadFile(ctx context.Context, relativePath, remoteKey strin
 		}
 	}
 
-	// Ensure directory exists
+	// Replace portable tokens with this device's paths in session content
+	if IsPortableContentPath(relativePath) {
+		data = s.paths.ResolveContent(data)
+	}
+
+	// Guard against path traversal from crafted remote keys
 	fullPath := filepath.Join(s.claudeDir, relativePath)
+	if !strings.HasPrefix(filepath.Clean(fullPath), filepath.Clean(s.claudeDir)+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to write outside %s: %s", s.claudeDir, relativePath)
+	}
+
+	// Ensure directory exists
 	dir := filepath.Dir(fullPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	// Write file
-	if err := os.WriteFile(fullPath, data, 0644); err != nil {
+	// Transcripts can contain secrets echoed by tools: keep them user-only
+	if err := os.WriteFile(fullPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 
@@ -458,13 +472,49 @@ func (s *Syncer) handleConflict(ctx context.Context, relativePath string, remote
 }
 
 func (s *Syncer) remoteKey(relativePath string) string {
-	// Add .age extension for encrypted files
-	return relativePath + ".age"
+	// Normalize machine-specific path segments, add .age extension
+	return s.paths.NormalizeRelPath(relativePath) + ".age"
 }
 
-func (s *Syncer) localPath(remoteKey string) string {
-	// Remove .age extension
-	return strings.TrimSuffix(remoteKey, ".age")
+// localPath maps a remote key back to a local relative path. ok is false when
+// the key uses a path_map token this device doesn't define.
+func (s *Syncer) localPath(remoteKey string) (string, bool) {
+	return s.paths.ResolveRelPath(strings.TrimSuffix(remoteKey, ".age"))
+}
+
+// buildRemoteMap maps remote objects to local relative paths, skipping
+// non-encrypted keys, MCP data, excluded paths, and keys with unknown path
+// tokens (reported via skipped). When a legacy un-normalized key and its
+// normalized replacement both exist, the normalized one wins.
+func (s *Syncer) buildRemoteMap(remoteObjects []storage.ObjectInfo) (remoteFiles map[string]storage.ObjectInfo, skipped []string) {
+	remoteFiles = make(map[string]storage.ObjectInfo)
+	for _, obj := range remoteObjects {
+		// Skip non-encrypted files
+		if !strings.HasSuffix(obj.Key, ".age") {
+			continue
+		}
+		localPath, ok := s.localPath(obj.Key)
+		if !ok {
+			skipped = append(skipped, obj.Key)
+			continue
+		}
+		// Skip external files (handled by MCP sync)
+		if strings.HasPrefix(localPath, "_external/") {
+			continue
+		}
+		// Skip excluded paths
+		if s.isExcluded(localPath) {
+			continue
+		}
+		if existing, dup := remoteFiles[localPath]; dup {
+			// Prefer the canonical (normalized) key over a legacy duplicate
+			if existing.Key == s.remoteKey(localPath) {
+				continue
+			}
+		}
+		remoteFiles[localPath] = obj
+	}
+	return remoteFiles, skipped
 }
 
 func (s *Syncer) GetState() *SyncState {
@@ -508,21 +558,7 @@ func (s *Syncer) PreviewPull(ctx context.Context) (*PullPreview, error) {
 	}
 
 	// Build remote file map
-	remoteFiles := make(map[string]storage.ObjectInfo)
-	for _, obj := range remoteObjects {
-		if !strings.HasSuffix(obj.Key, ".age") {
-			continue
-		}
-		localPath := s.localPath(obj.Key)
-		// Skip external files (handled by MCP sync)
-		if strings.HasPrefix(localPath, "_external/") {
-			continue
-		}
-		if s.isExcluded(localPath) {
-			continue
-		}
-		remoteFiles[localPath] = obj
-	}
+	remoteFiles, _ := s.buildRemoteMap(remoteObjects)
 
 	// Get current local files
 	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
@@ -615,21 +651,7 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 		return nil, fmt.Errorf("failed to list remote objects: %w", err)
 	}
 
-	remoteFiles := make(map[string]storage.ObjectInfo)
-	for _, obj := range remoteObjects {
-		if !strings.HasSuffix(obj.Key, ".age") {
-			continue
-		}
-		localPath := s.localPath(obj.Key)
-		// Skip external files (handled by MCP sync)
-		if strings.HasPrefix(localPath, "_external/") {
-			continue
-		}
-		if s.isExcluded(localPath) {
-			continue
-		}
-		remoteFiles[localPath] = obj
-	}
+	remoteFiles, _ := s.buildRemoteMap(remoteObjects)
 
 	// Find local-only and modified files
 	for relPath, info := range localFiles {


### PR DESCRIPTION
## Problem

Claude Code keys sessions by absolute path (`/Users/alice/my-app` → `~/.claude/projects/-Users-alice-my-app/`), so transcripts synced verbatim land in project directories `claude --resume` never looks at when usernames or layouts differ across machines.

## Approach

Normalize machine-specific path segments to portable tokens on push, resolve them to local paths on pull — the same strategy the MCP sync already uses, extended to `projects/` keys and transcript content:

- remote keys: `projects/-Users-alice-my-app/...` → `projects/${HOME}-my-app/...`
- content: `/Users/alice` → `${HOME}` in `.jsonl`/`.json`/`.md`/`.txt` under `projects/` and in `history.jsonl`

### What's included

- **Boundary-aware content replacement** — `/Users/merv` can never match inside `/Users/mervynlally`; replacement only fires when the path is followed by a non-name character or end of data.
- **`path_map` config** — for layouts that differ beyond the home dir, both machines map their own project root to a shared token (`~/work: WORK` / `~/Projects: WORK`). `HOME` is reserved and always mapped automatically.
- **`claude-sync migrate`** — converts this device's legacy literal-path remote keys in place (re-uploads with content normalization, deletes the old key). Keys owned by other devices are reported and left for that device's migrate run.
- **Safe pull behavior** — keys with tokens this device doesn't define are skipped with a clear error instead of materializing literal `${...}` directories; when a legacy key and its normalized replacement coexist, the normalized one wins.
- **Hardening on the new download path** — downloaded files are written `0600` (transcripts can contain secrets echoed by tools) and a path-traversal guard rejects keys that would resolve outside `~/.claude`.

### Tests

Unit coverage for encoding, normalize/resolve round-trips, boundary cases (including the username-prefix trap), token validation, plus an end-to-end test where a session pushed from a `/Users/alice` machine is pulled on a `/Users/bob` machine and lands under bob's encoded project dir with rewritten `cwd`.

### Compatibility

The `${HOME}` token format matches data already written by earlier builds of this branch — existing buckets need no conversion. Buckets with legacy literal keys are handled by `claude-sync migrate` (run once per device).
