### PR TITLE
feat: add S3-compatible custom-endpoint provider (Backblaze B2, MinIO, Wasabi, ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ claude-sync pull
 | **Cloudflare R2** | 10GB storage | Personal use (recommended) |
 | **AWS S3** | 5GB (12 months) | AWS users |
 | **Google Cloud Storage** | 5GB | GCP users |
+| **S3-compatible** | varies | Backblaze B2, MinIO, Wasabi, DigitalOcean Spaces, self-hosted |
 
 ### Step 2: Create a Bucket
 
@@ -112,6 +113,22 @@ You'll need: Access Key ID, Secret Access Key, Region
 3. Grant "Storage Object Admin" role → Create JSON key
 
 You'll need: Project ID, Service Account JSON file (or use `gcloud auth application-default login`)
+</details>
+
+<details>
+<summary><b>S3-compatible</b> (Backblaze B2, MinIO, Wasabi, DigitalOcean Spaces, ...)</summary>
+
+Any provider exposing an S3-compatible API works through the **S3-compatible (custom endpoint)** option. Create a bucket and an application key with your provider, then supply its S3 endpoint URL.
+
+Example (Backblaze B2):
+
+```bash
+claude-sync init --provider s3-compatible --endpoint https://s3.us-west-004.backblazeb2.com
+```
+
+You'll need: Endpoint URL, Access Key ID, Secret Access Key, Bucket. The signing region is auto-detected from the endpoint (e.g. `us-west-004`); for providers that ignore it, `auto` is used.
+
+> Custom endpoints automatically relax the AWS SDK's default integrity-checksum headers, which some S3-compatible providers reject. AWS S3 behavior is unchanged.
 </details>
 
 ### Step 3: Run Init

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -119,6 +119,9 @@ func initCmd() *cobra.Command {
 	// S3 flags
 	var s3Region string
 
+	// S3-compatible (custom endpoint) flags
+	var s3Endpoint string
+
 	// GCS flags
 	var gcsProjectID, gcsCredentialsFile string
 
@@ -128,14 +131,16 @@ func initCmd() *cobra.Command {
 		Long: `Set up cloud storage credentials and generate encryption keys.
 
 Supported providers:
-  - r2:  Cloudflare R2 (S3-compatible, free tier: 10GB)
-  - s3:  Amazon S3
-  - gcs: Google Cloud Storage
+  - r2:            Cloudflare R2 (S3-compatible, free tier: 10GB)
+  - s3:            Amazon S3
+  - gcs:           Google Cloud Storage
+  - s3-compatible: Any S3-compatible provider via custom endpoint (Backblaze B2, MinIO, Wasabi, ...)
 
 Examples:
   claude-sync init                # Full setup wizard
   claude-sync init --passphrase   # Re-enter passphrase only (keeps storage config)
-  claude-sync init --force        # Reset everything, start fresh`,
+  claude-sync init --force        # Reset everything, start fresh
+  claude-sync init --provider s3-compatible --endpoint https://s3.us-west-004.backblazeb2.com   # Backblaze B2`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Show banner
 			printBanner()
@@ -149,12 +154,12 @@ Examples:
 			}
 
 			// Normal flow: full setup
-			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile, usePassphrase, force)
+			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, s3Endpoint, gcsProjectID, gcsCredentialsFile, usePassphrase, force)
 		},
 	}
 
 	// Provider selection
-	cmd.Flags().StringVar(&provider, "provider", "", "Storage provider: r2, s3, or gcs")
+	cmd.Flags().StringVar(&provider, "provider", "", "Storage provider: r2, s3, gcs, or s3-compatible")
 	cmd.Flags().StringVar(&bucket, "bucket", "", "Bucket name")
 	cmd.Flags().BoolVar(&usePassphrase, "passphrase", false, "Derive encryption key from passphrase")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing config/key without prompting")
@@ -165,7 +170,10 @@ Examples:
 	cmd.Flags().StringVar(&secretKey, "secret-key", "", "Secret Access Key (R2/S3)")
 
 	// S3 flags
-	cmd.Flags().StringVar(&s3Region, "region", "", "AWS Region (S3)")
+	cmd.Flags().StringVar(&s3Region, "region", "", "Region (S3 / S3-compatible)")
+
+	// S3-compatible flags
+	cmd.Flags().StringVar(&s3Endpoint, "endpoint", "", "Custom S3-compatible endpoint URL (e.g. https://s3.us-west-004.backblazeb2.com)")
 
 	// GCS flags
 	cmd.Flags().StringVar(&gcsProjectID, "project-id", "", "GCP Project ID (GCS)")
@@ -216,7 +224,7 @@ func initPassphraseOnly(ctx context.Context, keyPath string) error {
 }
 
 // initFullSetup handles the full init wizard
-func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile string, usePassphrase, force bool) error {
+func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, s3Endpoint, gcsProjectID, gcsCredentialsFile string, usePassphrase, force bool) error {
 	if config.Exists() && !force {
 		var overwrite bool
 		prompt := &survey.Confirm{
@@ -241,6 +249,7 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 				"Cloudflare R2 (recommended - free tier: 10GB)",
 				"Amazon S3",
 				"Google Cloud Storage",
+				"S3-compatible (custom endpoint) — Backblaze B2, MinIO, Wasabi, ...",
 			},
 		}
 		var choice int
@@ -254,6 +263,8 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 			provider = "s3"
 		case 2:
 			provider = "gcs"
+		case 3:
+			provider = "s3-compatible"
 		}
 	}
 
@@ -268,6 +279,8 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 		storageCfg, err = runS3Wizard(accessKey, secretKey, s3Region, bucket)
 	case "gcs":
 		storageCfg, err = runGCSWizard(gcsProjectID, gcsCredentialsFile, bucket)
+	case "s3-compatible":
+		storageCfg, err = runS3CompatibleWizard(s3Endpoint, accessKey, secretKey, s3Region, bucket)
 	default:
 		return fmt.Errorf("unsupported provider: %s", provider)
 	}
@@ -644,6 +657,94 @@ func runS3Wizard(accessKey, secretKey, region, bucket string) (*storage.StorageC
 		AccessKeyID:     answers.AccessKey,
 		SecretAccessKey: answers.SecretKey,
 		Region:          answers.Region,
+	}, nil
+}
+
+// runS3CompatibleWizard configures any S3-compatible provider (Backblaze B2,
+// MinIO, Wasabi, DigitalOcean Spaces, ...) by collecting a custom endpoint URL.
+// It reuses the S3 storage engine (ProviderS3 with Endpoint set); the engine
+// relaxes checksum behavior for custom endpoints so these providers accept the
+// uploads. The signing region is pre-filled from the endpoint when derivable.
+func runS3CompatibleWizard(endpoint, accessKey, secretKey, region, bucket string) (*storage.StorageConfig, error) {
+	fmt.Printf("  %sS3-Compatible Setup%s\n\n", colorBold, colorReset)
+	printInfo("Works with any S3-compatible provider: Backblaze B2, MinIO, Wasabi, DigitalOcean Spaces, ...")
+	fmt.Println()
+	printInfo("You need the provider's S3 endpoint URL, an access key/secret, and a bucket.")
+	fmt.Println()
+
+	// Ask the endpoint first so the signing region can be derived from it.
+	if endpoint == "" {
+		q := &survey.Input{
+			Message: "S3 endpoint URL:",
+			Help:    "e.g. https://s3.us-west-004.backblazeb2.com (Backblaze B2)",
+		}
+		if err := survey.AskOne(q, &endpoint, survey.WithValidator(survey.Required)); err != nil {
+			return nil, err
+		}
+	}
+
+	if region == "" {
+		region = storage.RegionFromEndpoint(endpoint)
+	}
+
+	answers := struct {
+		AccessKey string
+		SecretKey string
+		Region    string
+		Bucket    string
+	}{
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+		Region:    region,
+		Bucket:    bucket,
+	}
+
+	questions := []*survey.Question{
+		{
+			Name: "AccessKey",
+			Prompt: &survey.Input{
+				Message: "Access Key ID:",
+				Default: accessKey,
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "SecretKey",
+			Prompt: &survey.Password{
+				Message: "Secret Access Key:",
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "Region",
+			Prompt: &survey.Input{
+				Message: "Region:",
+				Default: region,
+				Help:    "Signing region, auto-detected from the endpoint. 'auto' works for providers that ignore it.",
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "Bucket",
+			Prompt: &survey.Input{
+				Message: "Bucket name:",
+				Default: "claude-sync",
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	if err := survey.Ask(questions, &answers); err != nil {
+		return nil, err
+	}
+
+	return &storage.StorageConfig{
+		Provider:        storage.ProviderS3,
+		Bucket:          answers.Bucket,
+		AccessKeyID:     answers.AccessKey,
+		SecretAccessKey: answers.SecretKey,
+		Region:          answers.Region,
+		Endpoint:        storage.NormalizeEndpoint(endpoint),
 	}, nil
 }
 

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -2,7 +2,54 @@ package storage
 
 import (
 	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
 )
+
+// regionPattern matches AWS-style region identifiers (e.g. us-east-1, eu-central-1)
+// and Backblaze B2 regions (e.g. us-west-004), used to extract a signing region
+// from an S3-compatible endpoint host.
+var regionPattern = regexp.MustCompile(`^[a-z]{2}-[a-z]+-\d+$`)
+
+// NormalizeEndpoint ensures an S3-compatible endpoint is an absolute URI.
+// The AWS SDK's BaseEndpoint requires a scheme, so a bare host such as
+// "s3.eu-central-003.backblazeb2.com" is prefixed with "https://". Endpoints
+// that already carry a scheme (http:// or https://) are returned unchanged.
+func NormalizeEndpoint(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	if !strings.Contains(endpoint, "://") {
+		return "https://" + endpoint
+	}
+	return endpoint
+}
+
+// RegionFromEndpoint derives the signing region from an S3-compatible endpoint URL.
+// Providers like Backblaze B2 and Wasabi encode the region in the host as
+// s3.<region>.<provider>.com; SigV4 needs that exact region. When the region
+// cannot be confidently extracted (R2, MinIO, custom hosts) it returns "auto",
+// which works for providers that ignore the region. Returns "" for an empty endpoint.
+func RegionFromEndpoint(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+
+	host := endpoint
+	if u, err := url.Parse(endpoint); err == nil && u.Host != "" {
+		host = u.Host
+	}
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+
+	labels := strings.Split(host, ".")
+	if len(labels) >= 2 && labels[0] == "s3" && regionPattern.MatchString(labels[1]) {
+		return labels[1]
+	}
+	return "auto"
+}
 
 // StorageConfig holds configuration for any storage provider
 type StorageConfig struct {

--- a/internal/storage/config_test.go
+++ b/internal/storage/config_test.go
@@ -234,6 +234,112 @@ func TestStorageConfig_GetEndpoint(t *testing.T) {
 	}
 }
 
+func TestRegionFromEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		expected string
+	}{
+		{
+			name:     "empty endpoint yields empty region",
+			endpoint: "",
+			expected: "",
+		},
+		{
+			name:     "Backblaze B2 endpoint",
+			endpoint: "https://s3.us-west-004.backblazeb2.com",
+			expected: "us-west-004",
+		},
+		{
+			name:     "Backblaze B2 eu endpoint",
+			endpoint: "https://s3.eu-central-003.backblazeb2.com",
+			expected: "eu-central-003",
+		},
+		{
+			name:     "Wasabi endpoint",
+			endpoint: "https://s3.us-east-1.wasabisys.com",
+			expected: "us-east-1",
+		},
+		{
+			name:     "endpoint without scheme",
+			endpoint: "s3.us-west-004.backblazeb2.com",
+			expected: "us-west-004",
+		},
+		{
+			name:     "endpoint with port",
+			endpoint: "https://s3.us-west-004.backblazeb2.com:443",
+			expected: "us-west-004",
+		},
+		{
+			name:     "R2 style host is not extractable",
+			endpoint: "https://abc123.r2.cloudflarestorage.com",
+			expected: "auto",
+		},
+		{
+			name:     "MinIO style host is not extractable",
+			endpoint: "https://minio.example.com:9000",
+			expected: "auto",
+		},
+		{
+			name:     "AWS global endpoint does not mistake amazonaws for region",
+			endpoint: "https://s3.amazonaws.com",
+			expected: "auto",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RegionFromEndpoint(tt.endpoint)
+			if got != tt.expected {
+				t.Errorf("RegionFromEndpoint(%q) = %q, want %q", tt.endpoint, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		expected string
+	}{
+		{
+			name:     "empty stays empty",
+			endpoint: "",
+			expected: "",
+		},
+		{
+			name:     "bare host gets https scheme",
+			endpoint: "s3.eu-central-003.backblazeb2.com",
+			expected: "https://s3.eu-central-003.backblazeb2.com",
+		},
+		{
+			name:     "bare host with port gets https scheme",
+			endpoint: "minio.example.com:9000",
+			expected: "https://minio.example.com:9000",
+		},
+		{
+			name:     "https endpoint unchanged",
+			endpoint: "https://s3.us-west-004.backblazeb2.com",
+			expected: "https://s3.us-west-004.backblazeb2.com",
+		},
+		{
+			name:     "http endpoint scheme preserved",
+			endpoint: "http://minio.local:9000",
+			expected: "http://minio.local:9000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeEndpoint(tt.endpoint)
+			if got != tt.expected {
+				t.Errorf("NormalizeEndpoint(%q) = %q, want %q", tt.endpoint, got, tt.expected)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
 		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -40,19 +40,29 @@ func New(cfg *storage.StorageConfig) (storage.Storage, error) {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
-	var client *s3.Client
-	if cfg.Endpoint != "" {
-		client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-			o.BaseEndpoint = aws.String(cfg.Endpoint)
-		})
-	} else {
-		client = s3.NewFromConfig(awsCfg)
-	}
+	client := s3.NewFromConfig(awsCfg, buildS3Options(cfg))
 
 	return &Client{
 		client: client,
 		bucket: cfg.Bucket,
 	}, nil
+}
+
+// buildS3Options returns the functional options applied to the S3 client.
+// When a custom endpoint is configured (i.e. an S3-compatible provider such as
+// Backblaze B2, MinIO or Wasabi rather than AWS), it points the client at that
+// endpoint and relaxes checksum behavior to WhenRequired. The AWS SDK's default
+// (WhenSupported) sends x-amz-checksum integrity headers that several
+// S3-compatible providers reject; leaving the endpoint empty preserves the
+// AWS-native defaults unchanged.
+func buildS3Options(cfg *storage.StorageConfig) func(*s3.Options) {
+	return func(o *s3.Options) {
+		if cfg.Endpoint != "" {
+			o.BaseEndpoint = aws.String(storage.NormalizeEndpoint(cfg.Endpoint))
+			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+			o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
+		}
+	}
 }
 
 // Upload stores data with the given key

--- a/internal/storage/s3/s3_test.go
+++ b/internal/storage/s3/s3_test.go
@@ -1,0 +1,62 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/tawanorg/claude-sync/internal/storage"
+)
+
+func TestBuildS3Options_CustomEndpoint(t *testing.T) {
+	cfg := &storage.StorageConfig{
+		Endpoint: "https://s3.us-west-004.backblazeb2.com",
+	}
+
+	opts := &awss3.Options{}
+	buildS3Options(cfg)(opts)
+
+	if opts.BaseEndpoint == nil || *opts.BaseEndpoint != cfg.Endpoint {
+		t.Errorf("BaseEndpoint = %v, want %q", opts.BaseEndpoint, cfg.Endpoint)
+	}
+	if opts.RequestChecksumCalculation != aws.RequestChecksumCalculationWhenRequired {
+		t.Errorf("RequestChecksumCalculation = %v, want WhenRequired", opts.RequestChecksumCalculation)
+	}
+	if opts.ResponseChecksumValidation != aws.ResponseChecksumValidationWhenRequired {
+		t.Errorf("ResponseChecksumValidation = %v, want WhenRequired", opts.ResponseChecksumValidation)
+	}
+}
+
+func TestBuildS3Options_EndpointWithoutSchemeNormalized(t *testing.T) {
+	cfg := &storage.StorageConfig{
+		Endpoint: "s3.eu-central-003.backblazeb2.com", // no scheme
+	}
+
+	opts := &awss3.Options{}
+	buildS3Options(cfg)(opts)
+
+	want := "https://s3.eu-central-003.backblazeb2.com"
+	if opts.BaseEndpoint == nil || *opts.BaseEndpoint != want {
+		t.Errorf("BaseEndpoint = %v, want %q", opts.BaseEndpoint, want)
+	}
+}
+
+func TestBuildS3Options_AWSDefaultUnchanged(t *testing.T) {
+	cfg := &storage.StorageConfig{
+		Region: "us-east-1", // real AWS S3: no custom endpoint
+	}
+
+	opts := &awss3.Options{}
+	buildS3Options(cfg)(opts)
+
+	if opts.BaseEndpoint != nil {
+		t.Errorf("BaseEndpoint = %v, want nil for AWS", *opts.BaseEndpoint)
+	}
+	if opts.RequestChecksumCalculation != aws.RequestChecksumCalculationUnset {
+		t.Errorf("RequestChecksumCalculation = %v, want Unset (AWS default preserved)", opts.RequestChecksumCalculation)
+	}
+	if opts.ResponseChecksumValidation != aws.ResponseChecksumValidationUnset {
+		t.Errorf("ResponseChecksumValidation = %v, want Unset (AWS default preserved)", opts.ResponseChecksumValidation)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an **S3-compatible (custom endpoint)** option to `init`, so claude-sync works with any S3-compatible provider — Backblaze B2, MinIO, Wasabi, DigitalOcean Spaces, Hetzner, Ceph, etc. — not just R2/S3/GCS.

The S3 storage engine already honored a custom `Endpoint`; this exposes it through the wizard and a `--endpoint` flag rather than adding a whole new backend. **R2 stays the default and the AWS S3 path is unchanged.**

## Why

Several providers speak the S3 API but weren't reachable, because the S3 wizard only offered AWS regions and never set a custom endpoint. Backblaze B2 in particular (10GB free tier) is a natural fit alongside R2.

## What changed

- **`init` menu:** new "S3-compatible (custom endpoint)" entry after R2/S3/GCS, plus `runS3CompatibleWizard` (asks endpoint first, then key/secret/region/bucket).
- **`--endpoint` flag** for non-interactive setup.
- **Checksum compatibility:** for a custom endpoint the S3 client sets `RequestChecksumCalculation` / `ResponseChecksumValidation = WhenRequired`. The AWS SDK's default (`WhenSupported`) emits `x-amz-checksum-*` integrity headers that B2 and several other S3-compatible providers reject. AWS S3 (no custom endpoint) keeps the SDK default untouched.
- **Endpoint normalization:** a bare host such as `s3.us-west-004.backblazeb2.com` is prefixed with `https://` (the SDK's `BaseEndpoint` requires a full URI). The signing region is auto-derived from the endpoint host (e.g. `us-west-004`), falling back to `auto`.
- **README:** documents the option with a Backblaze B2 example.

## Tests

- `RegionFromEndpoint` (9 cases) and `NormalizeEndpoint` (5 cases) in `internal/storage`.
- `buildS3Options` in `internal/storage/s3` — verifies endpoint + checksum relaxation for custom endpoints, and that AWS defaults are preserved when no endpoint is set.
- `make check` (fmt + vet + full test suite) passes.

## Verified

Tested end-to-end against a real Backblaze B2 bucket (`init` → `push`); that round-trip is what surfaced both the checksum and bare-host-URI fixes.

---

🤖 Implemented with Claude Code.
