### PR TITLE
feat: add --scope to sync only portable session data (skip plugins/node_modules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ claude-sync pull
 | `~/.claude/settings.local.json` | Local settings |
 | `~/.claude/CLAUDE.md` | Global instructions |
 
+### Sync scope
+
+`init` asks whether to sync everything or just conversation data; you can also set it with `--scope`:
+
+| Scope | Syncs | Use when |
+|-------|-------|----------|
+| `full` (default) | everything in the table above | you want settings, skills, agents, and plugins mirrored too |
+| `sessions` | `projects/`, `history.jsonl`, `tasks/`, `plans/` only | you just want `claude --resume` to work across machines |
+
+```bash
+claude-sync init --scope sessions
+```
+
+**Why `sessions` exists:** `full` includes `plugins/`, whose plugin caches bundle `node_modules` and Python `.venv` trees — thousands of large, machine-/arch-specific files that are regenerated on demand and should not be synced. `sessions` skips them, keeping syncs small, fast, and portable. The scope is saved in `~/.claude-sync/config.yaml` and applies to every `push`/`pull`.
+
 ## Limitations
 
 ### Path-Based Session Indexing

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -111,6 +111,7 @@ func printWarning(text string) {
 
 func initCmd() *cobra.Command {
 	var provider, bucket string
+	var scope string
 	var usePassphrase, force bool
 
 	// R2 flags
@@ -149,12 +150,13 @@ Examples:
 			}
 
 			// Normal flow: full setup
-			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile, usePassphrase, force)
+			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile, scope, usePassphrase, force)
 		},
 	}
 
 	// Provider selection
 	cmd.Flags().StringVar(&provider, "provider", "", "Storage provider: r2, s3, or gcs")
+	cmd.Flags().StringVar(&scope, "scope", "", "Sync scope: 'full' (default, everything) or 'sessions' (conversation history only)")
 	cmd.Flags().StringVar(&bucket, "bucket", "", "Bucket name")
 	cmd.Flags().BoolVar(&usePassphrase, "passphrase", false, "Derive encryption key from passphrase")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing config/key without prompting")
@@ -216,7 +218,35 @@ func initPassphraseOnly(ctx context.Context, keyPath string) error {
 }
 
 // initFullSetup handles the full init wizard
-func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile string, usePassphrase, force bool) error {
+// resolveScope validates a --scope value, prompting interactively when empty.
+// Returns "full" or "sessions". "sessions" syncs only portable conversation
+// data; "full" syncs everything (the historical default).
+func resolveScope(scope string) (string, error) {
+	switch scope {
+	case config.ScopeFull, config.ScopeSessions:
+		return scope, nil
+	case "":
+		prompt := &survey.Select{
+			Message: "What should be synced?",
+			Options: []string{
+				"Sessions only — conversation history (recommended for syncing across machines)",
+				"Everything — settings, plugins, skills, agents, and sessions",
+			},
+		}
+		var c int
+		if err := survey.AskOne(prompt, &c); err != nil {
+			return "", err
+		}
+		if c == 0 {
+			return config.ScopeSessions, nil
+		}
+		return config.ScopeFull, nil
+	default:
+		return "", fmt.Errorf("invalid --scope %q (use \"full\" or \"sessions\")", scope)
+	}
+}
+
+func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, gcsProjectID, gcsCredentialsFile, scope string, usePassphrase, force bool) error {
 	if config.Exists() && !force {
 		var overwrite bool
 		prompt := &survey.Confirm{
@@ -393,10 +423,19 @@ skipKeyGen:
 		printSuccess("Encryption key verified")
 	}
 
+	// Resolve sync scope (prompts if not provided via --scope)
+	scope, err = resolveScope(scope)
+	if err != nil {
+		return err
+	}
+
 	// Save config
 	cfg := &config.Config{
 		Storage:       storageCfg,
 		EncryptionKey: "~/.claude-sync/age-key.txt",
+	}
+	if scope == config.ScopeSessions {
+		cfg.Scope = config.ScopeSessions
 	}
 
 	if err := config.Save(cfg); err != nil {
@@ -878,7 +917,7 @@ Examples:
 
 			// Check for first pull with existing local files
 			if !syncer.HasState() {
-				hasExisting, err := hasExistingClaudeFiles()
+				hasExisting, err := hasExistingClaudeFiles(cfg.Scope)
 				if err != nil {
 					return err
 				}
@@ -1823,13 +1862,13 @@ func clearRemoteStorage(ctx context.Context, store storage.Storage) error {
 }
 
 // hasExistingClaudeFiles checks if ~/.claude has any files that would be synced
-func hasExistingClaudeFiles() (bool, error) {
+func hasExistingClaudeFiles(scope string) (bool, error) {
 	claudeDir := config.ClaudeDir()
 	if _, err := os.Stat(claudeDir); os.IsNotExist(err) {
 		return false, nil
 	}
 
-	files, err := sync.GetLocalFiles(claudeDir, config.SyncPaths)
+	files, err := sync.GetLocalFiles(claudeDir, config.ScopedSyncPaths(scope))
 	if err != nil {
 		return false, err
 	}
@@ -1913,7 +1952,7 @@ func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, 
 	switch choice {
 	case 0:
 		// Backup and proceed
-		backupDir, err := createBackup()
+		backupDir, err := createBackup(syncer.Scope())
 		if err != nil {
 			return fmt.Errorf("failed to create backup: %w", err)
 		}
@@ -1934,7 +1973,7 @@ func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, 
 }
 
 // createBackup creates a backup of the current ~/.claude directory
-func createBackup() (string, error) {
+func createBackup(scope string) (string, error) {
 	claudeDir := config.ClaudeDir()
 	timestamp := time.Now().Format("20060102-150405")
 	backupDir := claudeDir + ".backup." + timestamp
@@ -1945,7 +1984,7 @@ func createBackup() (string, error) {
 	}
 
 	// Copy all syncable files to backup
-	files, err := sync.GetLocalFiles(claudeDir, config.SyncPaths)
+	files, err := sync.GetLocalFiles(claudeDir, config.ScopedSyncPaths(scope))
 	if err != nil {
 		return "", fmt.Errorf("failed to list files: %w", err)
 	}

--- a/cmd/claude-sync/scope_test.go
+++ b/cmd/claude-sync/scope_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tawanorg/claude-sync/internal/config"
+)
+
+// TestResolveScope covers the non-interactive branches of resolveScope: explicit
+// valid values pass through, and an unrecognized value is rejected. The empty
+// (interactive prompt) case requires a TTY and is exercised manually.
+func TestResolveScope(t *testing.T) {
+	t.Run("valid values pass through unchanged", func(t *testing.T) {
+		for _, in := range []string{config.ScopeFull, config.ScopeSessions} {
+			got, err := resolveScope(in)
+			if err != nil {
+				t.Errorf("resolveScope(%q) returned error: %v", in, err)
+			}
+			if got != in {
+				t.Errorf("resolveScope(%q) = %q, want %q", in, got, in)
+			}
+		}
+	})
+
+	t.Run("unrecognized value is rejected", func(t *testing.T) {
+		if _, err := resolveScope("bogus"); err == nil {
+			t.Error("resolveScope(\"bogus\") expected an error, got nil")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,12 @@ const (
 	// MCPRemoteKey is the remote storage key for synced MCP server configs.
 	// The _external/ prefix separates it from ~/.claude/-relative files.
 	MCPRemoteKey = "_external/mcp-servers.json"
+
+	// Sync scopes control which subset of ~/.claude is synced.
+	// ScopeFull (default) syncs everything in SyncPaths; ScopeSessions limits
+	// syncing to portable conversation data only.
+	ScopeFull     = "full"
+	ScopeSessions = "sessions"
 )
 
 type Config struct {
@@ -38,6 +44,10 @@ type Config struct {
 	// Exclude patterns (glob-style) for paths to skip during sync
 	Exclude []string `yaml:"exclude,omitempty"`
 
+	// Scope selects which subset of ~/.claude to sync: "full" (default, empty)
+	// or "sessions" (portable conversation data only). See ScopedSyncPaths.
+	Scope string `yaml:"scope,omitempty"`
+
 	// MCPSync enables syncing MCP server configs from ~/.claude.json
 	MCPSync bool `yaml:"mcp_sync,omitempty"`
 
@@ -51,7 +61,7 @@ type Config struct {
 	ClaudeJSONOverride string `yaml:"-"`
 }
 
-// SyncPaths defines which paths under ~/.claude to sync
+// SyncPaths defines which paths under ~/.claude to sync in the default "full" scope.
 var SyncPaths = []string{
 	"CLAUDE.md",
 	"settings.json",
@@ -65,6 +75,27 @@ var SyncPaths = []string{
 	"tasks",
 	"history.jsonl",
 	"rules",
+}
+
+// SessionSyncPaths is the subset synced in the "sessions" scope: portable,
+// high-value conversation data and its per-project work state. It deliberately
+// excludes plugins/ (which bundles non-portable node_modules and .venv trees),
+// along with machine-specific settings, skills, agents, and commands.
+var SessionSyncPaths = []string{
+	"projects",
+	"history.jsonl",
+	"tasks",
+	"plans",
+}
+
+// ScopedSyncPaths returns the sync path set for the given scope. "sessions"
+// limits syncing to SessionSyncPaths; "full", empty, or any unrecognized value
+// returns the complete SyncPaths so existing configs keep their behavior.
+func ScopedSyncPaths(scope string) []string {
+	if scope == ScopeSessions {
+		return SessionSyncPaths
+	}
+	return SyncPaths
 }
 
 func ConfigDirPath() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,11 +3,36 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/tawanorg/claude-sync/internal/storage"
 )
+
+func TestScopedSyncPaths(t *testing.T) {
+	t.Run("sessions scope is limited to portable session data", func(t *testing.T) {
+		got := ScopedSyncPaths("sessions")
+		want := []string{"projects", "history.jsonl", "tasks", "plans"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ScopedSyncPaths(\"sessions\") = %v, want %v", got, want)
+		}
+		for _, p := range got {
+			if p == "plugins" {
+				t.Fatal("sessions scope must never include plugins (bundles node_modules/.venv)")
+			}
+		}
+	})
+
+	t.Run("full, empty, and unknown scopes return the complete SyncPaths", func(t *testing.T) {
+		for _, scope := range []string{"full", "", "bogus"} {
+			got := ScopedSyncPaths(scope)
+			if !reflect.DeepEqual(got, SyncPaths) {
+				t.Errorf("ScopedSyncPaths(%q) = %v, want full SyncPaths %v", scope, got, SyncPaths)
+			}
+		}
+	})
+}
 
 func TestConfigDirPath(t *testing.T) {
 	path := ConfigDirPath()

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -121,6 +121,17 @@ func (s *Syncer) isExcluded(relPath string) bool {
 	return s.cfg.IsExcluded(relPath)
 }
 
+// syncPaths returns the set of ~/.claude paths to sync, honoring the
+// configured scope ("full" by default, or "sessions" for portable data only).
+func (s *Syncer) syncPaths() []string {
+	return config.ScopedSyncPaths(s.cfg.Scope)
+}
+
+// Scope returns the configured sync scope (empty means the default "full").
+func (s *Syncer) Scope() string {
+	return s.cfg.Scope
+}
+
 func (s *Syncer) log(format string, args ...interface{}) {
 	if !s.quiet {
 		fmt.Printf(format+"\n", args...)
@@ -132,7 +143,7 @@ func (s *Syncer) Push(ctx context.Context) (*SyncResult, error) {
 
 	s.progress(ProgressEvent{Action: "scan", Path: "Detecting changes..."})
 
-	changes, err := s.state.DetectChanges(s.claudeDir, config.SyncPaths, s.isExcluded)
+	changes, err := s.state.DetectChanges(s.claudeDir, s.syncPaths(), s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect changes: %w", err)
 	}
@@ -260,7 +271,7 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 	}
 
 	// Get current local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
+	localFiles, err := GetLocalFiles(s.claudeDir, s.syncPaths(), s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -364,7 +375,7 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 }
 
 func (s *Syncer) Status(ctx context.Context) ([]FileChange, error) {
-	return s.state.DetectChanges(s.claudeDir, config.SyncPaths, s.isExcluded)
+	return s.state.DetectChanges(s.claudeDir, s.syncPaths(), s.isExcluded)
 }
 
 func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
@@ -525,7 +536,7 @@ func (s *Syncer) PreviewPull(ctx context.Context) (*PullPreview, error) {
 	}
 
 	// Get current local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
+	localFiles, err := GetLocalFiles(s.claudeDir, s.syncPaths(), s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -604,7 +615,7 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 	var entries []DiffEntry
 
 	// Get local files
-	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
+	localFiles, err := GetLocalFiles(s.claudeDir, s.syncPaths(), s.isExcluded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds a `--scope` option so `init`/`push`/`pull` can sync only portable conversation data instead of all of `~/.claude`.

## Why

The default syncs everything in `SyncPaths`, including `plugins/`. Plugin caches bundle `node_modules` and Python `.venv` trees — thousands of large files. On one setup a `pull --dry-run` queued ~9,800 such files. They bloat the bucket and slow every sync (each file is individually encrypted + uploaded).

More seriously, **these files are not portable, so full-scope sync breaks cross-platform.** The bundled artifacts are arch-/OS-specific: native `.so`/`.node` binaries, `.venv` interpreters with hardcoded absolute paths, and `pyvenv.cfg` pointing at a specific Python install. Sync a macOS Apple-Silicon `~/.claude` down onto a Linux or Intel machine and those plugins land broken — wrong binaries, dead interpreter paths, cryptic import errors. In other words, `claude-sync` today effectively only works between identical platforms; anyone syncing across mixed machines (Apple Silicon ↔ Linux/Intel) hits this. That's a real problem, and it's silent — the sync "succeeds" but the result is corrupt.

`sessions` scope sidesteps all of it by syncing only the data that *is* portable.

## What changed

- New `--scope` flag (and an `init` prompt), persisted in config as `scope:`.
  - **`sessions`** → syncs `projects/`, `history.jsonl`, `tasks/`, `plans/` — everything needed for `claude --resume` to work across machines.
  - **`full`** → today's behavior, and the **default**, so existing setups are unchanged.
- `ScopedSyncPaths(scope)` in `internal/config` drives the selection; the `Syncer` honors it across `push`, `pull`, `PreviewPull`, and the pre-pull backup, so a sessions sync never scans or backs up the plugins tree.
- `init` prompts for scope when it isn't passed, recommending `sessions` for cross-machine use.

## Tests

- `ScopedSyncPaths` (sessions vs full/empty/unknown) and `resolveScope` flag validation.
- `make check` (fmt + vet + full suite) passes.

## Notes

Independent of #32 (S3-compatible endpoint) — this branch is based on `main` and touches different files apart from a small shared area in `cmd/claude-sync/main.go` (the `init` flag set).

🤖 Implemented with Claude Code.
