### PR TITLE
feat: verify sha256 checksums when self-updating

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -59,6 +59,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+      - name: Generate checksums
+        run: sha256sum claude-sync-* > checksums.txt
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,4 +69,4 @@ jobs:
             --repo ${{ github.repository }} \
             --title "claude-sync ${{ inputs.version }}" \
             --notes "Cross-platform build including Windows binaries." \
-            claude-sync-*
+            claude-sync-* checksums.txt

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,23 +1,52 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main"
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    ["@semantic-release/exec", {
-      "prepareCmd": "VERSION=${nextRelease.version} make build-all"
-    }],
-    ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }],
-    ["@semantic-release/github", {
-      "assets": [
-        {"path": "bin/claude-sync-darwin-arm64", "label": "claude-sync-darwin-arm64"},
-        {"path": "bin/claude-sync-darwin-amd64", "label": "claude-sync-darwin-amd64"},
-        {"path": "bin/claude-sync-linux-amd64", "label": "claude-sync-linux-amd64"},
-        {"path": "bin/claude-sync-linux-arm64", "label": "claude-sync-linux-arm64"}
-      ]
-    }]
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "VERSION=${nextRelease.version} make build-all"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "bin/claude-sync-darwin-arm64",
+            "label": "claude-sync-darwin-arm64"
+          },
+          {
+            "path": "bin/claude-sync-darwin-amd64",
+            "label": "claude-sync-darwin-amd64"
+          },
+          {
+            "path": "bin/claude-sync-linux-amd64",
+            "label": "claude-sync-linux-amd64"
+          },
+          {
+            "path": "bin/claude-sync-linux-arm64",
+            "label": "claude-sync-linux-arm64"
+          },
+          {
+            "path": "bin/checksums.txt",
+            "label": "checksums.txt"
+          }
+        ]
+      }
+    ]
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+`claude-sync` is a Go CLI that syncs `~/.claude/` (Claude Code state: sessions, agents, skills, plugins, settings, history, global `CLAUDE.md`) across devices via encrypted cloud storage (Cloudflare R2 / AWS S3 / GCS). Files are gzip-compressed, then age-encrypted before upload. The canonical binary is distributed as pre-compiled platform-specific npm packages; a tiny Node wrapper at `bin/claude-sync.js` dispatches to the right binary.
+
+## Common Commands
+
+```bash
+make build            # build ./bin/claude-sync for the host platform
+make test             # go test -v ./...
+make check            # pre-commit equivalent: gofmt -l, go vet, go test -short
+make fmt              # go fmt ./...
+make lint             # golangci-lint run (requires golangci-lint installed)
+make build-all        # cross-compile darwin/linux × arm64/amd64 into ./bin/
+make setup-hooks      # install .githooks/pre-commit (runs on every commit)
+
+# Run a single test
+go test -v -run TestName ./internal/sync/
+go test -v ./internal/crypto/ -run TestGenerateKeyFromPassphrase
+
+# Integration tests (require real R2 credentials; behind build tag)
+go test -tags=integration -v ./integration/...
+# or: cd integration && docker-compose up --build
+```
+
+Version is injected at build time: `-ldflags "-X main.version=<version>"`. `make build` pulls the version from `git describe --tags --always --dirty`.
+
+## Architecture
+
+Layered, with a pluggable storage abstraction:
+
+- **CLI layer** — `cmd/claude-sync/main.go`. Cobra commands (`init`, `push`, `pull`, `status`, `diff`, `conflicts`, `reset`, `update`, `changelog`, `mcp`) plus Survey-driven interactive wizards. All user-facing output lives here.
+- **Sync layer** — `internal/sync/`. `Syncer` orchestrates push/pull; `SyncState` (`state.json`) tracks per-file SHA256 hash + size + mtime + last-uploaded time. `DetectChanges` compares local files against state to produce `add/modify/delete` work items. Push/pull both run uploads/downloads with a worker pool (`defaultWorkers = 10`).
+- **Crypto layer** — `internal/crypto/encrypt.go`. Wraps `filippo.io/age` (X25519 + ChaCha20-Poly1305). Supports two key modes: random (`GenerateKey`) or passphrase-derived (`GenerateKeyFromPassphrase`, Argon2id with a **fixed salt** `sha256("claude-sync-v1")` so the same passphrase yields the same key on any device). The derived 32 bytes are clamped for X25519 then Bech32-encoded as an `AGE-SECRET-KEY-…` identity.
+- **Storage layer** — `internal/storage/`. `Storage` interface (`Upload`/`Download`/`Delete`/`DeleteBatch`/`List`/`Head`/`BucketExists`) with three adapters: `r2/` (AWS SDK v2 pointed at `<account>.r2.cloudflarestorage.com`), `s3/` (AWS SDK v2), `gcs/` (Google Cloud Storage SDK). Adapters **self-register** via `init()` functions setting package-level `storage.NewR2` / `NewS3` / `NewGCS` vars; `cmd/claude-sync/main.go` blank-imports them to wire up the factory (`storage.New`). Add new providers by following this pattern.
+- **Config layer** — `internal/config/config.go`. YAML at `~/.claude-sync/config.yaml` (perms 0600). Supports both new unified `storage:` block and legacy R2-only top-level fields — `GetStorageConfig()` handles migration. `SyncPaths` defines what gets synced under `~/.claude/`; edit there to change the sync scope.
+
+### On-disk layout
+
+```
+~/.claude-sync/         # tool's own state (perms 0600/0700)
+├── config.yaml         # storage + encryption config
+├── age-key.txt         # encryption identity (derived or random)
+└── state.json          # per-file hash/size/mtime + last push/pull times
+
+~/.claude/              # what gets synced (see config.SyncPaths)
+```
+
+### Sync semantics
+
+- **Remote keys** are local paths with `.age` appended. Files under `_external/` on remote are reserved for MCP sync (see below) and are filtered out of regular pull/diff.
+- **Push** encrypts only files whose current hash differs from state; deletions detected from state are batched via `DeleteBatch`.
+- **Pull** downloads when the local file is missing, or when remote `LastModified` is after the state's `Uploaded` time. If the local hash **also** differs from state (both sides changed), it's a **conflict**: local is kept, remote is written to `<path>.conflict.<timestamp>`. `claude-sync conflicts` resolves them (and updates state on resolution).
+- **First pull with existing local files** is handled specially in `cmd/claude-sync/main.go` (`handleFirstPullWithExistingFiles`): shows a preview diff and offers backup-to-`~/.claude.backup.<ts>`/overwrite/abort.
+- **Backward-compat read path**: decrypt always attempts gzip decompression only if magic `0x1f 0x8b` is present, so older uncompressed remote blobs still work. Write path always compresses.
+- **Key verification**: during `init`, after deriving the key, `verifyKeyMatchesRemote` downloads a small remote file and tries to decrypt it. Mismatch triggers the 3-way prompt (retry passphrase / clear remote / abort).
+
+### MCP sync
+
+`~/.claude.json` holds global MCP server configs. Unlike regular sync, MCP uses a **three-way merge** (`internal/sync/mcp.go`) against a baseline stored in `SyncState.MCPBaseline`. On pull, local vs remote vs baseline are merged; conflicting server entries keep local. Paths inside MCP server commands/args are home-relative-normalized (`NormalizeMCPServers`) before upload and resolved back to absolute on pull. Remote key is fixed: `_external/mcp-servers.json.age`. Toggle via `mcp_sync: true` in config or the `--include-mcp` flag.
+
+## Distribution & release
+
+- Pre-built binaries ship as 6 platform-specific npm packages under `npm/<platform>/` (`darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`, `win32-arm64`, `win32-x64`). `package.json` lists them as `optionalDependencies`; npm installs only the one matching the host. `bin/claude-sync.js` resolves and execs the right binary.
+- Releases are automated via **semantic-release** (`.releaserc.json`) on pushes to `main`. The `prepareCmd` runs `VERSION=${nextRelease.version} make build-all`, then uploads the 4 Unix binaries to GitHub Releases. `install.js` / `claude-sync update` both download from the GitHub Releases API.
+- Version bumps come from Conventional Commits (`feat:` → minor, `fix:` → patch, `feat!:`/`BREAKING CHANGE` → major). Don't hand-edit `CHANGELOG.md` or the version in `package.json` — semantic-release owns both.
+
+## CI & pre-commit
+
+- `.github/workflows/ci.yml` runs `go test -v ./...`, enforces **60% coverage** on `internal/*` packages, builds, and runs golangci-lint. Keep changes to `internal/` covered.
+- `.githooks/pre-commit` (enabled by `make setup-hooks`) runs `gofmt -l`, `go vet`, `go test ./... -short`, and golangci-lint if installed. Run `make check` locally before committing to mirror it.
+
+## Gotchas
+
+- **Path-based session indexing**: Claude Code keys session dirs by absolute filesystem path (e.g. `~/.claude/projects/-Users-alice-code-foo/`). Syncing does not remap paths, so sessions only resume on another device if the project lives at the same absolute path. This is a documented limitation, not a bug — see README "Limitations".
+- **Storage adapter imports**: anything outside `cmd/claude-sync/` that calls `storage.New(...)` must also blank-import the adapter packages it needs (see `internal/sync/sync.go` top). Forgetting this produces a runtime "unsupported storage provider" error, not a compile error.
+- **Symlinks are skipped** by `GetLocalFiles` — don't rely on symlinked content inside `~/.claude/` being synced.
+- **The Argon2 salt is intentionally fixed** in `crypto.GenerateKeyFromPassphrase`. Do not "fix" it to per-user random — doing so breaks cross-device sync (the whole point of passphrase mode).
+- **Do not add destructive operations** to the default code path without an explicit `--force` or interactive confirm — the CLI is careful about backups (`~/.claude.backup.<ts>`), key-mismatch detection, and `.conflict.<ts>` files for a reason.

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ lint:
 
 # Build for multiple platforms
 build-all: build-darwin build-linux
+	cd $(BUILD_DIR) && shasum -a 256 $(BINARY_NAME)-* > checksums.txt
 
 build-darwin:
 	GOOS=darwin GOARCH=arm64 $(GO) build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 ./cmd/claude-sync

--- a/README.md
+++ b/README.md
@@ -155,26 +155,35 @@ claude-sync pull
 | `~/.claude/settings.local.json` | Local settings |
 | `~/.claude/CLAUDE.md` | Global instructions |
 
-## Limitations
+## Cross-Device Path Mapping
 
-### Path-Based Session Indexing
-
-Claude Code indexes project sessions by **absolute filesystem path**. This tool syncs `~/.claude/projects/` but does not perform path remapping, which means:
+Claude Code indexes project sessions by **absolute filesystem path**:
 
 ```
-/Users/alice/Projects/my-app → ~/.claude/projects/-Users-alice-Projects-my-app/
-/Users/bob/code/my-app       → ~/.claude/projects/-Users-bob-code-my-app/
+/Users/alice/my-app → ~/.claude/projects/-Users-alice-my-app/
+/Users/bob/my-app   → ~/.claude/projects/-Users-bob-my-app/
 ```
 
-These are treated as **completely different projects** by Claude Code. After syncing, `claude --resume` on machine2 won't find sessions from machine1 if the project paths differ.
+Synced verbatim, those would be **different projects** and `claude --resume` on the second machine would never find the first machine's sessions. claude-sync solves this by translating paths during sync:
 
-**Workaround:** Use consistent absolute paths across all devices. For example:
+- **Home directories are mapped automatically.** Sessions are stored remotely under a portable `${HOME}` token (in both remote keys and transcript content), then rewritten to each device's real home on pull. Different usernames across machines just work.
+- **Other layout differences are configurable.** If one machine keeps projects in `~/work` and another in `~/Projects`, point both at the same token in `~/.claude-sync/config.yaml`:
 
-- Always clone repos to `~/Projects/` on every machine
-- Use symlinks to maintain the same path structure
-- Consider a standardized home directory structure
+  ```yaml
+  # machine 1
+  path_map:
+    ~/work: WORK
+  ```
 
-If you follow a consistent path convention, sessions will sync and resume correctly across devices.
+  ```yaml
+  # machine 2
+  path_map:
+    ~/Projects: WORK
+  ```
+
+  Sessions under either directory sync to the shared `${WORK}` namespace and resume correctly on both machines.
+
+**Upgrading from an older version?** Run `claude-sync migrate` once on each device to convert existing remote data to portable keys. Paths the current device doesn't own are left for the other device's migrate run.
 
 ## Commands
 
@@ -186,6 +195,7 @@ claude-sync status      # Show pending local changes
 claude-sync diff        # Show differences between local and remote
 claude-sync conflicts   # List and resolve conflicts
 claude-sync reset       # Reset configuration (forgot passphrase)
+claude-sync migrate     # Convert legacy remote keys to portable path-mapped keys
 claude-sync update      # Update to latest version
 claude-sync changelog   # Show release history
 claude-sync --help      # Show all commands

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ claude-sync diff        # Show differences between local and remote
 claude-sync conflicts   # List and resolve conflicts
 claude-sync reset       # Reset configuration (forgot passphrase)
 claude-sync migrate     # Convert legacy remote keys to portable path-mapped keys
-claude-sync update      # Update to latest version
+claude-sync update      # Update to latest version (verifies release checksums)
 claude-sync changelog   # Show release history
 claude-sync --help      # Show all commands
 ```

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1704,6 +1706,11 @@ Examples:
 				return fmt.Errorf("failed to download update: %w", err)
 			}
 
+			// Verify against the release's published checksums
+			if err := verifyChecksum(release, assetName, newBinary); err != nil {
+				return fmt.Errorf("refusing to install update: %w", err)
+			}
+
 			// Get current executable path
 			execPath, err := os.Executable()
 			if err != nil {
@@ -1759,6 +1766,49 @@ func getLatestRelease() (*GitHubRelease, error) {
 	}
 
 	return &release, nil
+}
+
+// verifyChecksum validates the downloaded binary against the checksums.txt
+// asset published with the release. Releases predating checksum publication
+// warn instead of failing; once checksums.txt is present, a missing entry or
+// a mismatch aborts the update.
+func verifyChecksum(release *GitHubRelease, assetName string, data []byte) error {
+	var checksumsURL string
+	for _, asset := range release.Assets {
+		if asset.Name == "checksums.txt" {
+			checksumsURL = asset.BrowserDownloadURL
+			break
+		}
+	}
+	if checksumsURL == "" {
+		fmt.Printf("%s!%s Release has no checksums.txt; skipping integrity verification\n", colorYellow, colorReset)
+		return nil
+	}
+
+	body, err := downloadBinary(checksumsURL)
+	if err != nil {
+		return fmt.Errorf("failed to download checksums.txt: %w", err)
+	}
+
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+
+	for _, line := range strings.Split(string(body), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		// sha256sum format: "<hash>  <filename>" ("*" prefix = binary mode)
+		if strings.TrimPrefix(fields[1], "*") != assetName {
+			continue
+		}
+		if !strings.EqualFold(fields[0], got) {
+			return fmt.Errorf("sha256 mismatch for %s: release lists %s, downloaded %s", assetName, fields[0], got)
+		}
+		fmt.Printf("%s✓%s Checksum verified\n", colorGreen, colorReset)
+		return nil
+	}
+	return fmt.Errorf("checksums.txt has no entry for %s", assetName)
 }
 
 func downloadBinary(url string) ([]byte, error) {

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -63,6 +63,7 @@ func main() {
 		diffCmd(),
 		conflictsCmd(),
 		resetCmd(),
+		migrateCmd(),
 		updateCmd(),
 		changelogCmd(),
 		mcpCmd(),
@@ -1536,6 +1537,93 @@ Examples:
 	cmd.Flags().BoolVar(&clearRemote, "remote", false, "Delete all files from cloud storage bucket")
 	cmd.Flags().BoolVar(&clearLocal, "local", false, "Clear local sync state")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func migrateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Rewrite legacy remote keys to portable path-mapped keys",
+		Long: `Re-upload this device's project files under portable, path-mapped remote
+keys and delete the legacy machine-specific keys.
+
+Older versions stored project sessions under keys derived from this machine's
+absolute paths (e.g. projects/-Users-alice-my-app/...), so sessions pulled on
+a device with a different username or layout were not resumable. New pushes
+use portable tokens (e.g. projects/${HOME}-my-app/...); migrate converts
+existing remote data in place.
+
+Run this once on every device. Keys owned by another device are left for that
+device's migrate run and reported as "left for other devices".`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			syncer, err := sync.NewSyncer(cfg, quiet)
+			if err != nil {
+				return err
+			}
+
+			if !quiet {
+				syncer.SetProgressFunc(func(event sync.ProgressEvent) {
+					if event.Error != nil {
+						fmt.Printf("\r%s✗%s %s: %v\n", colorYellow, colorReset, event.Path, event.Error)
+						return
+					}
+					if event.Action == "upload" && !event.Complete {
+						progress := fmt.Sprintf("[%d/%d]", event.Current, event.Total)
+						shortPath := util.TruncatePath(event.Path, 50)
+						fmt.Printf("\r%s↻%s %s%s%s %s%s",
+							colorCyan, colorReset,
+							colorDim, progress, colorReset,
+							shortPath,
+							strings.Repeat(" ", 10))
+					}
+				})
+				fmt.Printf("%s⋯%s Scanning remote for legacy keys...\n", colorDim, colorReset)
+			}
+
+			result, err := syncer.MigratePaths(context.Background())
+			if err != nil {
+				return err
+			}
+
+			if !quiet {
+				fmt.Println()
+				if len(result.Migrated) == 0 && len(result.Foreign) == 0 && len(result.Errors) == 0 {
+					fmt.Printf("%s✓%s Nothing to migrate\n", colorGreen, colorReset)
+					return nil
+				}
+
+				var parts []string
+				if len(result.Migrated) > 0 {
+					parts = append(parts, fmt.Sprintf("%s%d migrated%s", colorGreen, len(result.Migrated), colorReset))
+				}
+				if len(result.Foreign) > 0 {
+					parts = append(parts, fmt.Sprintf("%s%d left for other devices%s", colorDim, len(result.Foreign), colorReset))
+				}
+				if len(result.Errors) > 0 {
+					parts = append(parts, fmt.Sprintf("%s%d failed%s", colorYellow, len(result.Errors), colorReset))
+				}
+				fmt.Printf("%s✓%s Migration complete: %s\n", colorGreen, colorReset, strings.Join(parts, ", "))
+
+				if len(result.Foreign) > 0 {
+					fmt.Printf("\n%sRun 'claude-sync migrate' on your other devices to convert the remaining keys.%s\n", colorDim, colorReset)
+				}
+				if len(result.Errors) > 0 {
+					fmt.Printf("\n%sErrors:%s\n", colorYellow, colorReset)
+					for _, e := range result.Errors {
+						fmt.Printf("  %s•%s %v\n", colorYellow, colorReset, e)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
 
 	return cmd
 }

--- a/docs/specs/openclaw-bifrost-sync.md
+++ b/docs/specs/openclaw-bifrost-sync.md
@@ -1,0 +1,287 @@
+# Spec: Extending claude-sync to cover OpenClaw + Bifrost
+
+> Status: **Draft** (2026-05-15) · Owner: Merv · Tracking issue: TBD
+> Motivation: today's session created ~4 hours of agent topology + Bifrost configuration that sits in `~/.openclaw/` and `~/.config/bifrost/`, neither of which any sync mechanism covers. A machine failure would lose all of it.
+
+## 1. Context
+
+`claude-sync` v1.8.x today syncs `~/.claude/` only — the SyncPaths in `internal/config/config.go` are `CLAUDE.md`, `settings*.json`, `agents`, `commands`, `skills`, `plugins`, `projects`, `history.jsonl`, `rules`. Plus the MCP special-case (three-way merge against `~/.claude.json` → `_external/mcp-servers.json.age`).
+
+Three sync domains are in play in the Nexura environment:
+
+| Domain | Where | Covered by |
+|---|---|---|
+| Claude Code state | `~/.claude/` | **claude-sync** ✓ |
+| Repo source + docs | `~/nexura/` | git (NexuraPlatform/nexura) ✓ |
+| **OpenClaw config + indexed memory** | `~/.openclaw/` | **nothing** ❌ |
+| **Bifrost gateway config + history** | `~/.config/bifrost/` (Docker volume) | nightly local backup only ❌ for cross-device |
+
+The OpenClaw gap is the biggest. `~/.openclaw/openclaw.json` contains the entire agent topology — five agent profiles with their model routing, the `models.providers.bifrost.models` catalog with deliberate exclusions, `memorySearch.query` tuning, the OClaw virtual-key apiKey. None of it is backed up or replicable from elsewhere. Losing the laptop loses the topology.
+
+## 2. Goals
+
+**V1 (this spec)** — sync the OpenClaw agent topology + indexed memory store across devices using the existing claude-sync crypto and storage layers.
+
+- [ ] New "openclaw" sync pack. Same R2/S3/GCS backend, same age encryption.
+- [ ] `claude-sync push --pack openclaw` / `claude-sync pull --pack openclaw`.
+- [ ] Backwards-compatible: existing `~/.claude/` sync unchanged for users not enabling the pack.
+- [ ] Smart conflict handling for `openclaw.json` (three-way merge analogous to MCP).
+- [ ] First-pull safety (back up existing local `~/.openclaw/` before overwriting).
+
+**V2 (future)** — bifrost pack covering `~/.config/bifrost/config.db` (provider/VK/governance config), excluding `logs.db` (rebuilds from activity). Deferred because the data lives in a Docker named volume, which adds complexity.
+
+**V3 (future)** — auto-sync triggers (LaunchAgent on file change). V1+V2 are manual push/pull.
+
+## 3. Non-goals
+
+- ❌ Syncing `~/.openclaw/agents/*/sessions/*.jsonl` transcripts. They can be hundreds of MB per agent and provide marginal cross-device value.
+- ❌ Syncing `~/.openclaw/agents/*/sessions/*.deleted.*` archive files.
+- ❌ Syncing `~/.openclaw/agents/*/logs/*`. Logs are local diagnostic state.
+- ❌ Syncing `~/.openclaw/cron/runs/*`. Cron run history is local.
+- ❌ Real-time replication. Manual push/pull is the V1 model.
+- ❌ Conflict-free CRDT merging. We use the same "keep local, write remote to `.conflict.<ts>`" pattern as the existing file-level sync.
+- ❌ Syncing Bifrost `logs.db` (~870 MB and growing) in V2. Only `config.db`.
+
+## 4. Design — the "sync pack" concept
+
+Today's `Syncer` walks a single global `SyncPaths`. The V1 refactor turns each domain into a **Pack** with its own configuration, file walker, and merge behavior.
+
+### 4.1 Pack interface (Go)
+
+```go
+// internal/sync/pack.go (new)
+package sync
+
+type Pack interface {
+    // Identity
+    Name() string                              // "claude", "mcp", "openclaw"
+    Enabled() bool                             // from config
+
+    // Filesystem
+    LocalRoot() string                         // e.g. ~/.openclaw
+    Walk() ([]LocalFile, error)                // honors Include/Exclude
+    RemotePrefix() string                      // "claude/" or "openclaw/"
+
+    // Merge semantics
+    DetectChanges(state *SyncState) ([]WorkItem, error)
+    MergeStrategy(path string) MergeStrategy   // FileLevel | ThreeWayJSON | SnapshotOnly
+
+    // First-pull safety
+    HasNonEmptyLocalState() bool
+    BackupLocal(backupDir string) error
+}
+
+type MergeStrategy int
+const (
+    FileLevelKeepLocal MergeStrategy = iota   // default — current claude behavior
+    ThreeWayJSONMerge                          // for openclaw.json (analogous to MCP)
+    SnapshotOnly                               // for SQLite — newest wins, no merge
+)
+```
+
+### 4.2 Config schema additions
+
+`~/.claude-sync/config.yaml` gains a `packs:` section. Existing fields stay at top level for backwards-compat.
+
+```yaml
+# existing
+storage:
+  provider: r2
+  bucket: <private>
+  account_id: <private>
+encryption_key_path: ~/.claude-sync/age-key.txt
+
+# NEW
+packs:
+  claude:
+    enabled: true                              # default — preserves current behavior
+  mcp:
+    enabled: true                              # default — preserves MCP three-way merge
+  openclaw:
+    enabled: false                             # opt-in
+    local_root: ~/.openclaw
+    include:
+      - openclaw.json
+      - agents/**/agent/AGENTS.md              # per-agent charters if any
+      - agents/**/agent/models.json
+      - memory/main.sqlite                     # snapshot semantics
+      - memory/**/short-term-recall.json
+      - cron/jobs.json                         # cron definitions (not runs/)
+      - skills/                                # custom local skills (NOT ClawHub-installed under nexura/)
+    exclude:
+      - agents/**/sessions/                    # transcripts — huge, low value
+      - agents/**/logs/                        # local diagnostics
+      - cron/runs/                             # cron run history
+      - "**/.cache/"
+    merge:
+      openclaw.json: three_way_json            # avoid clobbering local virtual-key changes
+      memory/main.sqlite: snapshot_only        # newest wins; rebuildable from source
+```
+
+### 4.3 Remote layout
+
+`R2 bucket / <prefix>` is unchanged for the claude pack. New packs land under `_external/<pack-name>/`:
+
+```
+<bucket>/
+├── CLAUDE.md.age                              # existing
+├── agents/                                    # existing
+├── projects/                                  # existing
+├── _external/
+│   ├── mcp-servers.json.age                   # existing MCP
+│   └── openclaw/                              # NEW
+│       ├── openclaw.json.age
+│       ├── agents/main/agent/models.json.age
+│       ├── memory/main.sqlite.age
+│       └── cron/jobs.json.age
+```
+
+The `_external/` convention preserves the "this is sync'd but lives outside `~/.claude/`" semantics already established for MCP.
+
+### 4.4 State tracking
+
+Single `state.json` extended to namespace per-pack:
+
+```json
+{
+  "version": 2,
+  "last_push_at": "2026-05-15T15:58:28Z",
+  "packs": {
+    "claude": {
+      "files": { "CLAUDE.md": { "hash": "...", "size": 1234, "mtime": "...", "uploaded": "..." } }
+    },
+    "openclaw": {
+      "files": { "openclaw.json": { "hash": "...", "size": 5678, "mtime": "...", "uploaded": "..." } }
+    }
+  }
+}
+```
+
+A v1→v2 state migration on first run.
+
+### 4.5 Three-way JSON merge for `openclaw.json`
+
+Same pattern as MCP. On push:
+1. Load local `openclaw.json` (current state).
+2. Load `state.packs.openclaw.baseline` (last-synced version stored in state.json).
+3. Pull remote `_external/openclaw/openclaw.json.age`, decrypt.
+4. Compute `localΔ = local - baseline` and `remoteΔ = remote - baseline`.
+5. Apply both deltas. Conflicts (same key changed differently on both sides) → keep local, log warning.
+6. Push merged result, update baseline.
+
+Specific care for two keys:
+- `models.providers.bifrost.apiKey` — never merge, always keep local (machine-specific VK)
+- `agents.list[].id` — list-of-objects merge by id; conflicts within an entry resolved per-field
+
+### 4.6 SQLite snapshot semantics
+
+For `memory/main.sqlite`:
+- Treat as opaque blob.
+- On conflict: rename remote to `memory/main.sqlite.conflict.<timestamp>.sqlite`, write to disk for forensic comparison. Local stays canonical.
+- Pull-side: if local exists and remote is newer (LastModified > state.uploaded), prompt or auto-backup-then-overwrite (configurable).
+
+## 5. Implementation phases
+
+### Phase 1 — Pack abstraction refactor (1–2 days)
+- [ ] Define `Pack` interface in `internal/sync/pack.go`.
+- [ ] Extract current `~/.claude/` sync into a `ClaudePack` (no behavior change).
+- [ ] Extract MCP sync into an `MCPPack` (no behavior change).
+- [ ] State.json v1→v2 migration.
+- [ ] All existing tests pass unchanged.
+- [ ] **Acceptance**: `claude-sync push` and `pull` behave identically for existing users.
+
+### Phase 2 — OpenClaw pack (2–3 days)
+- [ ] Add `OpenClawPack` implementing `Pack`.
+- [ ] Implement include/exclude glob walking.
+- [ ] Three-way JSON merge for `openclaw.json` (extend `internal/sync/mcp.go` patterns).
+- [ ] SQLite snapshot semantics for `memory/main.sqlite`.
+- [ ] First-pull safety: detect non-empty local `~/.openclaw/`, prompt/backup to `~/.openclaw.backup.<ts>/`.
+- [ ] CLI: `--pack` flag on push/pull/status/diff to scope operations.
+- [ ] `claude-sync init` walks the user through enabling the openclaw pack.
+- [ ] Conflict resolution UX: extend `claude-sync conflicts` to handle openclaw paths.
+- [ ] Integration test (under `integration/`) with a real R2 round-trip.
+- [ ] **Acceptance**: push from machine A, pull on machine B, `openclaw memory status` works identically on both.
+
+### Phase 3 — Bifrost pack (deferred, ~3–4 days)
+- [ ] Decide source: `docker run --rm -v bifrost-data:/d:ro ... cat /d/config.db` vs. helper sidecar pattern. Probably read directly from the named-volume mount path on Linux, use helper container on macOS.
+- [ ] Coordinate with the nightly `backup.sh` so the sync doesn't double-snapshot.
+- [ ] Exclude `logs.db` explicitly (size).
+- [ ] Pull-side: write into the named volume (requires container coordination — restart Bifrost or accept brief inconsistency).
+- [ ] Decide whether to sync `~/.config/bifrost/sync-keys` + `backup.sh` themselves (they live on the bind-mount adjacent to the volume).
+
+### Phase 4 — Auto-sync triggers (deferred)
+- [ ] LaunchAgent (macOS) / systemd timer (Linux) for periodic push.
+- [ ] File-watcher option (fsnotify on `openclaw.json`).
+- [ ] Cap push frequency (debounce 60s).
+
+## 6. Storage policy
+
+All packs use the same R2/S3/GCS backend the user has configured. Today's setup already uses a **private Cloudflare R2 bucket** in the user's own account — no shared/public bucket exposure. Spec requirement: documentation must call this out so a new user setting up claude-sync uses their own private bucket from the start.
+
+Specifically:
+- README + `claude-sync init` wizard must require a private bucket choice; never offer a "shared" or "demo" option.
+- Encryption at rest: age (X25519 + ChaCha20-Poly1305), already in place. No change.
+- Encryption in transit: TLS to R2/S3/GCS, already in place.
+- Key material is **local-only** (`~/.claude-sync/age-key.txt`, mode 0600). Never sync the encryption key itself.
+
+## 7. Operational ownership — open-source vs. private fork
+
+`claude-sync` is currently the user's own public Go CLI on GitHub. Question raised: should it be forked into a private nexura repo since it's becoming load-bearing for the company's infrastructure?
+
+### Stay public, contribute upstream (recommended)
+**Pros**
+- Public release pipeline (semantic-release, GitHub Releases, npm distribution) already works.
+- Other users benefit; contributions back are possible.
+- Less maintenance overhead — one codebase.
+
+**Cons**
+- New features are released publicly. Competitors see your tooling.
+- The pack abstraction is non-trivial; reviewers (you) take public scrutiny.
+
+### Private fork (defer unless real need)
+**Pros**
+- Nexura-specific extensions (e.g., a `nexura-internal` pack with tenant-specific config) don't leak.
+- Release cadence is internal.
+- Can include private dependencies if needed.
+
+**Cons**
+- Two codebases to keep in sync.
+- npm distribution gets messier (private packages, auth on installs).
+- The pack interface in this spec is generic — no obvious need for private-only code.
+
+**Recommendation**: extend public `claude-sync` with the pack architecture (it's generic and useful to anyone), and only fork if a future Nexura-specific need arises that genuinely doesn't belong upstream. Keep nexura-specific config (paths, exclusions, R2 bucket) in `~/.claude-sync/config.yaml`, not in source.
+
+If you want a "Nexura distribution" feel, an alternative is a thin wrapper repo (`NexuraPlatform/claude-sync-nexura`) that pins a claude-sync version + ships an opinionated `config.yaml` template. That's ~1 file of code, no fork divergence to maintain.
+
+## 8. Test plan
+
+- [ ] Unit: each Pack's Walk, DetectChanges, MergeStrategy in isolation.
+- [ ] Unit: state.json v1→v2 migration round-trip.
+- [ ] Unit: three-way merge of `openclaw.json` — three scenarios:
+  1. No conflict (different keys changed on each side).
+  2. Same-key conflict (keep local).
+  3. List-of-objects merge by id (e.g., `agents.list[].model` changed on remote but added a new agent locally).
+- [ ] Integration: round-trip an `openclaw.json` between two machines via R2.
+- [ ] Integration: SQLite snapshot conflict produces `.conflict.<ts>` file.
+- [ ] Integration: first pull with existing local `~/.openclaw/` triggers backup-or-abort prompt.
+- [ ] Backwards-compat: existing `claude-sync push/pull/status` works on a config.yaml without `packs:` section.
+
+## 9. Open questions
+
+1. **Cron jobs sync**: should `~/.openclaw/cron/jobs.json` sync? On machine B, those crons would auto-fire and could double-charge (run twice across both machines). Probably **don't sync** by default; if needed, manual import command.
+2. **Skills under `~/.openclaw/skills/`** vs `~/nexura/skills/`: the latter goes via git. The former (if any) is unclear — what's the difference? May need a one-time audit.
+3. **First-pull backup destination**: `~/.openclaw.backup.<ts>/` lives forever unless cleaned. Add a `claude-sync prune-backups` command?
+4. **Multi-account**: if a user has both personal and work OpenClaw setups, do they want separate buckets / encryption keys per environment? V1 says no; document the limitation.
+5. **Bifrost on Linux vs macOS**: when V2 lands, the Docker named-volume access pattern differs. Probably needs platform-specific source resolvers.
+6. **Conflict UX on `openclaw.json`**: a single `.conflict.<ts>` file alongside the live one (matching existing pattern), or interactive merge in the CLI? V1: file-based, document the manual reconciliation flow.
+
+## 10. Acceptance for the V1 ship
+
+- Documented in README under "Packs".
+- `claude-sync init` prompts for which packs to enable.
+- `claude-sync push --pack openclaw` works against a real R2 bucket.
+- `claude-sync pull --pack openclaw` on a fresh machine restores the full agent topology (verified by `openclaw agents list` showing the same 5 agents).
+- Memory store round-trip works (`openclaw memory status` shows the same indexed files + chunk count post-pull).
+- Existing `claude-sync push/pull/status/diff/conflicts/reset/update` commands still work with no config change.
+- All unit + integration tests green.
+- 60% test coverage on `internal/` maintained (per existing CI gate in `CLAUDE.md`).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,17 @@ type Config struct {
 	// MCPSync enables syncing MCP server configs from ~/.claude.json
 	MCPSync bool `yaml:"mcp_sync,omitempty"`
 
+	// PathMap maps local directory prefixes to shared token names so project
+	// sessions stay resumable across devices with different layouts.
+	// The home directory is always mapped (token HOME); add entries here when
+	// project roots differ beyond that, e.g.:
+	//   path_map:
+	//     ~/work: WORK        # this device keeps projects in ~/work
+	// with the other device mapping its own location to the same token:
+	//   path_map:
+	//     ~/Projects: WORK
+	PathMap map[string]string `yaml:"path_map,omitempty"`
+
 	// ClaudeDirOverride allows overriding the default ~/.claude path (for testing)
 	ClaudeDirOverride string `yaml:"-"`
 
@@ -124,6 +135,19 @@ func Load() (*Config, error) {
 	if cfg.EncryptionKey != "" && cfg.EncryptionKey[0] == '~' {
 		home, _ := os.UserHomeDir()
 		cfg.EncryptionKey = filepath.Join(home, cfg.EncryptionKey[1:])
+	}
+
+	// Expand ~ in path_map keys
+	if len(cfg.PathMap) > 0 {
+		home, _ := os.UserHomeDir()
+		expanded := make(map[string]string, len(cfg.PathMap))
+		for p, name := range cfg.PathMap {
+			if p != "" && p[0] == '~' {
+				p = filepath.Join(home, p[1:])
+			}
+			expanded[p] = name
+		}
+		cfg.PathMap = expanded
 	}
 
 	// Set default endpoint for Cloudflare R2

--- a/internal/sync/migrate.go
+++ b/internal/sync/migrate.go
@@ -1,0 +1,81 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MigrateResult describes the outcome of migrating legacy remote keys to
+// portable (path-normalized) keys.
+type MigrateResult struct {
+	Migrated []string // local paths re-uploaded under normalized keys
+	Foreign  []string // legacy keys owned by another device (run migrate there)
+	Errors   []error
+}
+
+// MigratePaths rewrites this device's legacy remote project keys to the
+// portable token form: each file is re-uploaded under its normalized key
+// (with content normalization applied) and the legacy key is deleted.
+//
+// Keys that don't match any of this device's path mappings — typically
+// projects pushed from another machine — are left untouched and reported in
+// Foreign; running migrate on that machine completes the migration.
+func (s *Syncer) MigratePaths(ctx context.Context) (*MigrateResult, error) {
+	result := &MigrateResult{}
+
+	remoteObjects, err := s.storage.List(ctx, "projects/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remote objects: %w", err)
+	}
+
+	var legacyKeys []string
+	for _, obj := range remoteObjects {
+		if !strings.HasSuffix(obj.Key, ".age") {
+			continue
+		}
+		raw := strings.TrimSuffix(obj.Key, ".age")
+		if seg, _, ok := splitProjectsPath(raw); !ok || strings.HasPrefix(seg, tokenPrefix) {
+			continue // already normalized
+		}
+		if s.isExcluded(raw) {
+			continue
+		}
+		normalized := s.paths.NormalizeRelPath(raw)
+		if normalized == raw {
+			// Not under any of this device's mapped prefixes
+			result.Foreign = append(result.Foreign, raw)
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(s.claudeDir, raw)); err != nil {
+			// We can't re-encrypt content we don't have locally
+			result.Foreign = append(result.Foreign, raw)
+			continue
+		}
+		legacyKeys = append(legacyKeys, raw)
+	}
+
+	total := len(legacyKeys)
+	for i, raw := range legacyKeys {
+		s.progress(ProgressEvent{Action: "upload", Path: raw, Current: i + 1, Total: total})
+		if err := s.uploadFile(ctx, raw); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", raw, err))
+			continue
+		}
+		if err := s.storage.Delete(ctx, raw+".age"); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("delete legacy %s: %w", raw, err))
+			continue
+		}
+		result.Migrated = append(result.Migrated, raw)
+	}
+
+	if total > 0 {
+		if err := s.state.Save(); err != nil {
+			return result, fmt.Errorf("failed to save state: %w", err)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/sync/paths.go
+++ b/internal/sync/paths.go
@@ -1,0 +1,214 @@
+package sync
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// PathMapper translates machine-specific project paths to portable tokens on
+// push and back to local paths on pull, so sessions started on one device are
+// resumable on another even when home directories or project layouts differ.
+//
+// Claude Code stores sessions under ~/.claude/projects/<encoded-cwd>/ where
+// <encoded-cwd> is the working directory with every non-alphanumeric character
+// replaced by "-" (e.g. /Users/alice/my-app -> -Users-alice-my-app). Because
+// the encoding is keyed to the absolute path, a transcript synced verbatim to
+// a machine with a different username or layout lands in a directory that
+// `claude --resume` never looks at.
+//
+// The mapper rewrites two things:
+//   - remote keys:   projects/-Users-alice-my-app/... -> projects/${HOME}-my-app/...
+//   - file content:  /Users/alice -> ${HOME} (cwd fields, tool paths)
+//
+// HOME is always mapped. Additional prefixes (e.g. ~/work on one machine,
+// ~/Projects on another) can be mapped via the path_map config, with both
+// machines pointing their own local path at the same token name.
+type PathMapper struct {
+	// mappings ordered longest local path first so the most specific prefix wins
+	mappings []pathMapping
+}
+
+type pathMapping struct {
+	name      string // token name, e.g. "HOME", "WORK"
+	localPath string // absolute local path, no trailing slash
+	encLocal  string // localPath in Claude Code's directory encoding
+	normRe    *regexp.Regexp
+	normRepl  []byte // replacement template: token ($-escaped) + boundary group
+}
+
+var pathTokenNameRe = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// NewPathMapper builds a mapper for this device. userMap maps local absolute
+// paths (already ~-expanded) to token names shared across devices.
+func NewPathMapper(homeDir string, userMap map[string]string) (*PathMapper, error) {
+	m := &PathMapper{}
+
+	add := func(name, localPath string) error {
+		localPath = strings.TrimRight(localPath, "/")
+		if localPath == "" {
+			return nil
+		}
+		if !pathTokenNameRe.MatchString(name) {
+			return fmt.Errorf("invalid path_map token %q: use uppercase letters, digits, underscores (e.g. WORK)", name)
+		}
+		// Boundary-aware: only replace the path when it is not followed by a
+		// name character, so /Users/merv never matches inside /Users/mervynlally.
+		re := regexp.MustCompile(regexp.QuoteMeta(localPath) + `([^A-Za-z0-9_.-]|$)`)
+		m.mappings = append(m.mappings, pathMapping{
+			name:      name,
+			localPath: localPath,
+			encLocal:  EncodeClaudePath(localPath),
+			normRe:    re,
+			// "$$" = literal "$" in a regexp replacement template; without it
+			// "${HOME}" would itself be read as a group reference
+			normRepl: []byte("$${" + name + "}${1}"),
+		})
+		return nil
+	}
+
+	for localPath, name := range userMap {
+		if strings.EqualFold(name, "HOME") {
+			return nil, fmt.Errorf("path_map token HOME is reserved (the home directory is mapped automatically)")
+		}
+		if err := add(name, localPath); err != nil {
+			return nil, err
+		}
+	}
+	if homeDir != "" {
+		if err := add("HOME", homeDir); err != nil {
+			return nil, err
+		}
+	}
+
+	// Longest local path first so ~/work maps to its own token before ~ does.
+	sort.SliceStable(m.mappings, func(i, j int) bool {
+		return len(m.mappings[i].localPath) > len(m.mappings[j].localPath)
+	})
+
+	return m, nil
+}
+
+// EncodeClaudePath applies Claude Code's project directory encoding: every
+// character outside [A-Za-z0-9] becomes "-".
+func EncodeClaudePath(p string) string {
+	var b strings.Builder
+	b.Grow(len(p))
+	for _, r := range p {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+// Tokens use the ${NAME} form in both remote keys and file content. This
+// matches the format already written to existing buckets; note that a literal
+// "${HOME}" in transcript content (e.g. a quoted shell snippet) is therefore
+// indistinguishable from a normalized path and resolves to the local home
+// directory on pull.
+func pathToken(name string) string { return "${" + name + "}" }
+
+const tokenPrefix = "${"
+
+// splitProjectsPath splits "projects/<seg>/rest" into seg and "/rest".
+// ok is false for paths not under projects/.
+func splitProjectsPath(relPath string) (seg, rest string, ok bool) {
+	const prefix = "projects/"
+	if !strings.HasPrefix(relPath, prefix) {
+		return "", "", false
+	}
+	remainder := relPath[len(prefix):]
+	if i := strings.IndexByte(remainder, '/'); i >= 0 {
+		return remainder[:i], remainder[i:], true
+	}
+	return remainder, "", true
+}
+
+// NormalizeRelPath rewrites a local relative path to its portable remote form.
+// Only project directory segments are affected; everything else is unchanged.
+// A nil mapper performs no translation (legacy behavior).
+func (m *PathMapper) NormalizeRelPath(relPath string) string {
+	if m == nil {
+		return relPath
+	}
+	seg, rest, ok := splitProjectsPath(relPath)
+	if !ok || strings.HasPrefix(seg, tokenPrefix) {
+		return relPath
+	}
+	for _, mp := range m.mappings {
+		if seg == mp.encLocal || strings.HasPrefix(seg, mp.encLocal+"-") {
+			return "projects/" + pathToken(mp.name) + seg[len(mp.encLocal):] + rest
+		}
+	}
+	return relPath
+}
+
+// ResolveRelPath rewrites a portable remote path back to a local relative
+// path. ok is false when the path uses a token this device has no mapping
+// for (the caller should skip the file and tell the user to extend path_map).
+func (m *PathMapper) ResolveRelPath(relPath string) (string, bool) {
+	if m == nil {
+		return relPath, true
+	}
+	seg, rest, isProject := splitProjectsPath(relPath)
+	if !isProject || !strings.HasPrefix(seg, tokenPrefix) {
+		return relPath, true
+	}
+	for _, mp := range m.mappings {
+		token := pathToken(mp.name)
+		if strings.HasPrefix(seg, token) {
+			return "projects/" + mp.encLocal + seg[len(token):] + rest, true
+		}
+	}
+	return relPath, false
+}
+
+// NormalizeContent replaces this device's mapped path prefixes with portable
+// tokens in file content. Replacement is boundary-aware so one user's home
+// path never matches inside a longer username.
+func (m *PathMapper) NormalizeContent(data []byte) []byte {
+	if m == nil {
+		return data
+	}
+	for _, mp := range m.mappings {
+		data = mp.normRe.ReplaceAll(data, mp.normRepl)
+	}
+	return data
+}
+
+// ResolveContent replaces portable tokens with this device's local paths.
+func (m *PathMapper) ResolveContent(data []byte) []byte {
+	if m == nil {
+		return data
+	}
+	for _, mp := range m.mappings {
+		data = bytes.ReplaceAll(data, []byte(pathToken(mp.name)), []byte(mp.localPath))
+	}
+	return data
+}
+
+// IsPortableContentPath reports whether content path translation applies to
+// this relative path: text formats under projects/ plus the prompt history.
+// Conflict copies (path.conflict.<timestamp>) inherit the base path's rule.
+func IsPortableContentPath(relPath string) bool {
+	if i := strings.Index(relPath, ".conflict."); i >= 0 {
+		relPath = relPath[:i]
+	}
+	if relPath == "history.jsonl" {
+		return true
+	}
+	if !strings.HasPrefix(relPath, "projects/") {
+		return false
+	}
+	switch path.Ext(relPath) {
+	case ".jsonl", ".json", ".md", ".txt":
+		return true
+	}
+	return false
+}

--- a/internal/sync/paths_test.go
+++ b/internal/sync/paths_test.go
@@ -1,0 +1,299 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func mustMapper(t *testing.T, home string, userMap map[string]string) *PathMapper {
+	t.Helper()
+	m, err := NewPathMapper(home, userMap)
+	if err != nil {
+		t.Fatalf("NewPathMapper: %v", err)
+	}
+	return m
+}
+
+func TestEncodeClaudePath(t *testing.T) {
+	cases := map[string]string{
+		"/Users/alice/my-app":      "-Users-alice-my-app",
+		"/Users/merv/.config/brc":  "-Users-merv--config-brc",
+		"C:\\Users\\merv\\app_1":   "C--Users-merv-app-1",
+		"/home/bob/Projects/RedXY": "-home-bob-Projects-RedXY",
+	}
+	for in, want := range cases {
+		if got := EncodeClaudePath(in); got != want {
+			t.Errorf("EncodeClaudePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeResolveRelPath(t *testing.T) {
+	alice := mustMapper(t, "/Users/alice", map[string]string{"/Users/alice/work": "WORK"})
+	bob := mustMapper(t, "/Users/bob", map[string]string{"/Users/bob/Projects": "WORK"})
+
+	cases := []struct {
+		local      string // on alice's machine
+		normalized string
+		onBob      string
+	}{
+		{
+			"projects/-Users-alice-my-app/sess.jsonl",
+			"projects/${HOME}-my-app/sess.jsonl",
+			"projects/-Users-bob-my-app/sess.jsonl",
+		},
+		{
+			// most specific mapping wins over HOME
+			"projects/-Users-alice-work-api/sess.jsonl",
+			"projects/${WORK}-api/sess.jsonl",
+			"projects/-Users-bob-Projects-api/sess.jsonl",
+		},
+		{
+			// exact project at the mapped root
+			"projects/-Users-alice-work/sess.jsonl",
+			"projects/${WORK}/sess.jsonl",
+			"projects/-Users-bob-Projects/sess.jsonl",
+		},
+		{
+			// non-projects paths untouched
+			"settings.json",
+			"settings.json",
+			"settings.json",
+		},
+		{
+			// foreign machine's directory left alone
+			"projects/-Users-zed-app/sess.jsonl",
+			"projects/-Users-zed-app/sess.jsonl",
+			"projects/-Users-zed-app/sess.jsonl",
+		},
+	}
+
+	for _, c := range cases {
+		norm := alice.NormalizeRelPath(c.local)
+		if norm != c.normalized {
+			t.Errorf("NormalizeRelPath(%q) = %q, want %q", c.local, norm, c.normalized)
+			continue
+		}
+		resolved, ok := bob.ResolveRelPath(norm)
+		if !ok {
+			t.Errorf("ResolveRelPath(%q): unexpectedly unresolvable", norm)
+			continue
+		}
+		if resolved != c.onBob {
+			t.Errorf("ResolveRelPath(%q) = %q, want %q", norm, resolved, c.onBob)
+		}
+	}
+}
+
+func TestNormalizeRelPathUsernamePrefixTrap(t *testing.T) {
+	// /Users/merv must not match inside /Users/mervynlally's encoded dirs
+	merv := mustMapper(t, "/Users/merv", nil)
+	in := "projects/-Users-mervynlally-nexura/sess.jsonl"
+	if got := merv.NormalizeRelPath(in); got != in {
+		t.Errorf("NormalizeRelPath(%q) = %q, want unchanged", in, got)
+	}
+	// but its own dirs do match
+	own := "projects/-Users-merv-nexura/sess.jsonl"
+	if got := merv.NormalizeRelPath(own); got != "projects/${HOME}-nexura/sess.jsonl" {
+		t.Errorf("NormalizeRelPath(%q) = %q", own, got)
+	}
+}
+
+func TestResolveRelPathUnknownToken(t *testing.T) {
+	m := mustMapper(t, "/Users/bob", nil)
+	if _, ok := m.ResolveRelPath("projects/${WORK}-api/sess.jsonl"); ok {
+		t.Error("expected unknown token to be unresolvable")
+	}
+}
+
+func TestContentRoundTrip(t *testing.T) {
+	alice := mustMapper(t, "/Users/merv", nil)
+	bob := mustMapper(t, "/Users/mervynlally", nil)
+
+	in := []byte(`{"cwd":"/Users/merv/nexura","note":"see /Users/mervynlally/nexura and /Users/merv"}`)
+	norm := alice.NormalizeContent(in)
+
+	want := `{"cwd":"${HOME}/nexura","note":"see /Users/mervynlally/nexura and ${HOME}"}`
+	if string(norm) != want {
+		t.Fatalf("NormalizeContent = %s, want %s", norm, want)
+	}
+
+	resolved := bob.ResolveContent(norm)
+	wantResolved := `{"cwd":"/Users/mervynlally/nexura","note":"see /Users/mervynlally/nexura and /Users/mervynlally"}`
+	if string(resolved) != wantResolved {
+		t.Fatalf("ResolveContent = %s, want %s", resolved, wantResolved)
+	}
+}
+
+func TestContentBoundaries(t *testing.T) {
+	m := mustMapper(t, "/Users/merv", nil)
+
+	// dotted and dashed continuations are part of a different name, not a boundary
+	for _, s := range []string{"/Users/merv.bak/x", "/Users/merv-old/x", "/Users/mervyn/x"} {
+		if got := m.NormalizeContent([]byte(s)); string(got) != s {
+			t.Errorf("NormalizeContent(%q) = %q, should be untouched", s, got)
+		}
+	}
+	// end of data is a boundary
+	if got := m.NormalizeContent([]byte("/Users/merv")); string(got) != "${HOME}" {
+		t.Errorf("NormalizeContent at EOF = %q", got)
+	}
+}
+
+func TestPathMapperValidation(t *testing.T) {
+	if _, err := NewPathMapper("/Users/a", map[string]string{"/x": "home"}); err == nil {
+		t.Error("expected reserved-name error for HOME (case-insensitive)")
+	}
+	if _, err := NewPathMapper("/Users/a", map[string]string{"/x": "my-work"}); err == nil {
+		t.Error("expected invalid token name error")
+	}
+	if _, err := NewPathMapper("/Users/a", map[string]string{"/x": "WORK_2"}); err != nil {
+		t.Errorf("valid token rejected: %v", err)
+	}
+}
+
+func TestIsPortableContentPath(t *testing.T) {
+	cases := map[string]bool{
+		"history.jsonl":                                           true,
+		"projects/-Users-a-x/sess.jsonl":                          true,
+		"projects/-Users-a-x/memory/notes.md":                     true,
+		"projects/-Users-a-x/sess.jsonl.conflict.20260610-120000": true,
+		"projects/-Users-a-x/img.png":                             false,
+		"settings.json":                                           false,
+		"agents/foo.md":                                           false,
+	}
+	for in, want := range cases {
+		if got := IsPortableContentPath(in); got != want {
+			t.Errorf("IsPortableContentPath(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestCrossDeviceSessionSync simulates two devices with different usernames
+// sharing one bucket: a session pushed from alice's machine must land on
+// bob's machine under bob's encoded project directory with rewritten content.
+func TestCrossDeviceSessionSync(t *testing.T) {
+	syncerA, store, claudeDirA := testSyncer(t)
+	syncerA.paths = mustMapper(t, "/Users/alice", nil)
+
+	sessDir := filepath.Join(claudeDirA, "projects", "-Users-alice-my-app")
+	if err := os.MkdirAll(sessDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"cwd":"/Users/alice/my-app","type":"user"}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessDir, "sess.jsonl"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := syncerA.Push(context.Background()); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	wantKey := "projects/${HOME}-my-app/sess.jsonl.age"
+	if _, err := store.Download(context.Background(), wantKey); err != nil {
+		t.Fatalf("expected normalized remote key %s: %v", wantKey, err)
+	}
+
+	// Second device: same bucket and key, different username
+	tmpB := t.TempDir()
+	claudeDirB := filepath.Join(tmpB, ".claude")
+	if err := os.MkdirAll(claudeDirB, 0755); err != nil {
+		t.Fatal(err)
+	}
+	stateB, err := LoadStateFromDir(tmpB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncerB := NewSyncerWith(syncerA.cfg, store, syncerA.encryptor, stateB, claudeDirB, true)
+	syncerB.paths = mustMapper(t, "/Users/bob", nil)
+
+	result, err := syncerB.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("pull errors: %v", result.Errors)
+	}
+
+	localPath := filepath.Join(claudeDirB, "projects", "-Users-bob-my-app", "sess.jsonl")
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("expected session under bob's project dir: %v", err)
+	}
+	want := `{"cwd":"/Users/bob/my-app","type":"user"}` + "\n"
+	if string(data) != want {
+		t.Errorf("content = %s, want %s", data, want)
+	}
+
+	info, _ := os.Stat(localPath)
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("downloaded file mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestMigratePaths(t *testing.T) {
+	syncer, store, claudeDir := testSyncer(t)
+	ctx := context.Background()
+
+	// Create the local session file
+	sessDir := filepath.Join(claudeDir, "projects", "-Users-alice-my-app")
+	if err := os.MkdirAll(sessDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	relPath := "projects/-Users-alice-my-app/sess.jsonl"
+	if err := os.WriteFile(filepath.Join(claudeDir, relPath), []byte(`{"cwd":"/Users/alice/my-app"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push under legacy (identity) keys, as an old version would have
+	syncer.paths = mustMapper(t, "/nonexistent-home-zz", nil)
+	if _, err := syncer.Push(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Download(ctx, relPath+".age"); err != nil {
+		t.Fatalf("legacy key missing after push: %v", err)
+	}
+
+	// A key owned by another device: no local copy here
+	if err := store.Upload(ctx, "projects/-Users-zed-other/x.jsonl.age", []byte("opaque")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upgrade: mapper now knows this machine is alice's
+	syncer.paths = mustMapper(t, "/Users/alice", nil)
+
+	result, err := syncer.MigratePaths(ctx)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("migrate errors: %v", result.Errors)
+	}
+	if len(result.Migrated) != 1 || result.Migrated[0] != relPath {
+		t.Errorf("Migrated = %v, want [%s]", result.Migrated, relPath)
+	}
+	if len(result.Foreign) != 1 || result.Foreign[0] != "projects/-Users-zed-other/x.jsonl" {
+		t.Errorf("Foreign = %v", result.Foreign)
+	}
+
+	if _, err := store.Download(ctx, relPath+".age"); err == nil {
+		t.Error("legacy key still present after migrate")
+	}
+	if _, err := store.Download(ctx, "projects/${HOME}-my-app/sess.jsonl.age"); err != nil {
+		t.Errorf("normalized key missing after migrate: %v", err)
+	}
+	if _, err := store.Download(ctx, "projects/-Users-zed-other/x.jsonl.age"); err != nil {
+		t.Errorf("foreign key should be untouched: %v", err)
+	}
+
+	// Second run is a no-op for this device
+	result2, err := syncer.MigratePaths(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result2.Migrated) != 0 {
+		t.Errorf("second migrate should migrate nothing, got %v", result2.Migrated)
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -34,6 +34,7 @@ type Syncer struct {
 	quiet      bool
 	onProgress ProgressFunc
 	cfg        *config.Config
+	paths      *PathMapper
 }
 
 type SyncResult struct {
@@ -85,6 +86,12 @@ func NewSyncer(cfg *config.Config, quiet bool) (*Syncer, error) {
 		claudeDir = cfg.ClaudeDirOverride
 	}
 
+	homeDir, _ := os.UserHomeDir()
+	mapper, err := NewPathMapper(homeDir, cfg.PathMap)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Syncer{
 		storage:   store,
 		encryptor: enc,
@@ -92,11 +99,14 @@ func NewSyncer(cfg *config.Config, quiet bool) (*Syncer, error) {
 		claudeDir: claudeDir,
 		quiet:     quiet,
 		cfg:       cfg,
+		paths:     mapper,
 	}, nil
 }
 
 // NewSyncerWith creates a Syncer with pre-built dependencies (for testing).
 func NewSyncerWith(cfg *config.Config, store storage.Storage, enc *crypto.Encryptor, state *SyncState, claudeDir string, quiet bool) *Syncer {
+	homeDir, _ := os.UserHomeDir()
+	mapper, _ := NewPathMapper(homeDir, cfg.PathMap)
 	return &Syncer{
 		storage:   store,
 		encryptor: enc,
@@ -104,6 +114,7 @@ func NewSyncerWith(cfg *config.Config, store storage.Storage, enc *crypto.Encryp
 		claudeDir: claudeDir,
 		quiet:     quiet,
 		cfg:       cfg,
+		paths:     mapper,
 	}
 }
 
@@ -241,22 +252,10 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 	}
 
 	// Build remote file map
-	remoteFiles := make(map[string]storage.ObjectInfo)
-	for _, obj := range remoteObjects {
-		// Skip non-encrypted files
-		if !strings.HasSuffix(obj.Key, ".age") {
-			continue
-		}
-		localPath := s.localPath(obj.Key)
-		// Skip external files (handled by MCP sync)
-		if strings.HasPrefix(localPath, "_external/") {
-			continue
-		}
-		// Skip excluded paths
-		if s.isExcluded(localPath) {
-			continue
-		}
-		remoteFiles[localPath] = obj
+	remoteFiles, skipped := s.buildRemoteMap(remoteObjects)
+	for _, key := range skipped {
+		result.Errors = append(result.Errors,
+			fmt.Errorf("%s: unknown path token; add the matching path_map entry on this device", key))
 	}
 
 	// Get current local files
@@ -376,6 +375,11 @@ func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
+	// Replace machine-specific paths with portable tokens in session content
+	if IsPortableContentPath(relativePath) {
+		data = s.paths.NormalizeContent(data)
+	}
+
 	// Compress
 	compressed, err := gzipCompress(data)
 	if err != nil {
@@ -424,15 +428,25 @@ func (s *Syncer) downloadFile(ctx context.Context, relativePath, remoteKey strin
 		}
 	}
 
-	// Ensure directory exists
+	// Replace portable tokens with this device's paths in session content
+	if IsPortableContentPath(relativePath) {
+		data = s.paths.ResolveContent(data)
+	}
+
+	// Guard against path traversal from crafted remote keys
 	fullPath := filepath.Join(s.claudeDir, relativePath)
+	if !strings.HasPrefix(filepath.Clean(fullPath), filepath.Clean(s.claudeDir)+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to write outside %s: %s", s.claudeDir, relativePath)
+	}
+
+	// Ensure directory exists
 	dir := filepath.Dir(fullPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	// Write file
-	if err := os.WriteFile(fullPath, data, 0644); err != nil {
+	// Transcripts can contain secrets echoed by tools: keep them user-only
+	if err := os.WriteFile(fullPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 
@@ -458,13 +472,49 @@ func (s *Syncer) handleConflict(ctx context.Context, relativePath string, remote
 }
 
 func (s *Syncer) remoteKey(relativePath string) string {
-	// Add .age extension for encrypted files
-	return relativePath + ".age"
+	// Normalize machine-specific path segments, add .age extension
+	return s.paths.NormalizeRelPath(relativePath) + ".age"
 }
 
-func (s *Syncer) localPath(remoteKey string) string {
-	// Remove .age extension
-	return strings.TrimSuffix(remoteKey, ".age")
+// localPath maps a remote key back to a local relative path. ok is false when
+// the key uses a path_map token this device doesn't define.
+func (s *Syncer) localPath(remoteKey string) (string, bool) {
+	return s.paths.ResolveRelPath(strings.TrimSuffix(remoteKey, ".age"))
+}
+
+// buildRemoteMap maps remote objects to local relative paths, skipping
+// non-encrypted keys, MCP data, excluded paths, and keys with unknown path
+// tokens (reported via skipped). When a legacy un-normalized key and its
+// normalized replacement both exist, the normalized one wins.
+func (s *Syncer) buildRemoteMap(remoteObjects []storage.ObjectInfo) (remoteFiles map[string]storage.ObjectInfo, skipped []string) {
+	remoteFiles = make(map[string]storage.ObjectInfo)
+	for _, obj := range remoteObjects {
+		// Skip non-encrypted files
+		if !strings.HasSuffix(obj.Key, ".age") {
+			continue
+		}
+		localPath, ok := s.localPath(obj.Key)
+		if !ok {
+			skipped = append(skipped, obj.Key)
+			continue
+		}
+		// Skip external files (handled by MCP sync)
+		if strings.HasPrefix(localPath, "_external/") {
+			continue
+		}
+		// Skip excluded paths
+		if s.isExcluded(localPath) {
+			continue
+		}
+		if existing, dup := remoteFiles[localPath]; dup {
+			// Prefer the canonical (normalized) key over a legacy duplicate
+			if existing.Key == s.remoteKey(localPath) {
+				continue
+			}
+		}
+		remoteFiles[localPath] = obj
+	}
+	return remoteFiles, skipped
 }
 
 func (s *Syncer) GetState() *SyncState {
@@ -508,21 +558,7 @@ func (s *Syncer) PreviewPull(ctx context.Context) (*PullPreview, error) {
 	}
 
 	// Build remote file map
-	remoteFiles := make(map[string]storage.ObjectInfo)
-	for _, obj := range remoteObjects {
-		if !strings.HasSuffix(obj.Key, ".age") {
-			continue
-		}
-		localPath := s.localPath(obj.Key)
-		// Skip external files (handled by MCP sync)
-		if strings.HasPrefix(localPath, "_external/") {
-			continue
-		}
-		if s.isExcluded(localPath) {
-			continue
-		}
-		remoteFiles[localPath] = obj
-	}
+	remoteFiles, _ := s.buildRemoteMap(remoteObjects)
 
 	// Get current local files
 	localFiles, err := GetLocalFiles(s.claudeDir, config.SyncPaths, s.isExcluded)
@@ -615,21 +651,7 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 		return nil, fmt.Errorf("failed to list remote objects: %w", err)
 	}
 
-	remoteFiles := make(map[string]storage.ObjectInfo)
-	for _, obj := range remoteObjects {
-		if !strings.HasSuffix(obj.Key, ".age") {
-			continue
-		}
-		localPath := s.localPath(obj.Key)
-		// Skip external files (handled by MCP sync)
-		if strings.HasPrefix(localPath, "_external/") {
-			continue
-		}
-		if s.isExcluded(localPath) {
-			continue
-		}
-		remoteFiles[localPath] = obj
-	}
+	remoteFiles, _ := s.buildRemoteMap(remoteObjects)
 
 	// Find local-only and modified files
 	for relPath, info := range localFiles {


### PR DESCRIPTION
## What

`claude-sync update` (and the npm installer indirectly) downloads release binaries with no integrity check — SECURITY-AUDIT.md items M2/M3. This PR closes the gap end to end:

- **Release pipelines publish `checksums.txt`** — both the semantic-release flow (`make build-all` now emits `bin/checksums.txt`, added as a release asset) and the manual `build-release.yml` workflow (`sha256sum` step before `gh release create`).
- **`update` verifies before installing** — downloads the release's `checksums.txt`, computes the SHA-256 of the fetched binary, and aborts on a mismatch or a missing entry. The parser handles the `sha256sum` `*` binary-mode prefix and compares case-insensitively.

## Compatibility

Releases that predate checksum publication have no `checksums.txt` asset; `update` prints a warning and proceeds, so older releases stay installable. From the first release after this merges, verification is enforced.
