### PR TITLE
fix: pass scope argument to createBackup in permissions test

### DIFF
--- a/cmd/claude-sync/backup_test.go
+++ b/cmd/claude-sync/backup_test.go
@@ -28,7 +28,7 @@ func TestCreateBackupSetsRestrictivePermissions(t *testing.T) {
 		t.Fatalf("Failed to create helper.json: %v", err)
 	}
 
-	backupDir, err := createBackup()
+	backupDir, err := createBackup("full")
 	if err != nil {
 		t.Fatalf("createBackup failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

`go test ./cmd/claude-sync` fails to compile on current `main`:

```
cmd/claude-sync/backup_test.go:31:20: not enough arguments in call to createBackup
	have ()
	want (string)
```

`createBackup` gained a `scope` parameter in #33, but the permissions test added in #24 still calls it with no arguments — the two landed independently so neither PR could see the conflict. This passes `"full"` (the default scope), matching the test's setup which creates files across all sync paths.

## Testing

`go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)