### PR TITLE
feat: redesign paths management and improve MCP sync UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,12 @@ Version is injected at build time: `-ldflags "-X main.version=<version>"`. `make
 
 Layered, with a pluggable storage abstraction:
 
-- **CLI layer** — `cmd/claude-sync/main.go`. Cobra commands (`init`, `push`, `pull`, `status`, `diff`, `conflicts`, `reset`, `update`, `changelog`, `mcp`) plus Survey-driven interactive wizards. All user-facing output lives here.
+- **CLI layer** — `cmd/claude-sync/main.go`. Cobra commands (`init`, `push`, `pull`, `status`, `diff`, `conflicts`, `reset`, `update`, `changelog`, `mcp`, `paths`) plus Survey-driven interactive wizards. All user-facing output lives here.
 - **Sync layer** — `internal/sync/`. `Syncer` orchestrates push/pull; `SyncState` (`state.json`) tracks per-file SHA256 hash + size + mtime + last-uploaded time. `DetectChanges` compares local files against state to produce `add/modify/delete` work items. Push/pull both run uploads/downloads with a worker pool (`defaultWorkers = 10`).
 - **Crypto layer** — `internal/crypto/encrypt.go`. Wraps `filippo.io/age` (X25519 + ChaCha20-Poly1305). Supports two key modes: random (`GenerateKey`) or passphrase-derived (`GenerateKeyFromPassphrase`, Argon2id with a **fixed salt** `sha256("claude-sync-v1")` so the same passphrase yields the same key on any device). The derived 32 bytes are clamped for X25519 then Bech32-encoded as an `AGE-SECRET-KEY-…` identity.
 - **Storage layer** — `internal/storage/`. `Storage` interface (`Upload`/`Download`/`Delete`/`DeleteBatch`/`List`/`Head`/`BucketExists`) with three adapters: `r2/` (AWS SDK v2 pointed at `<account>.r2.cloudflarestorage.com`), `s3/` (AWS SDK v2), `gcs/` (Google Cloud Storage SDK). Adapters **self-register** via `init()` functions setting package-level `storage.NewR2` / `NewS3` / `NewGCS` vars; `cmd/claude-sync/main.go` blank-imports them to wire up the factory (`storage.New`). Add new providers by following this pattern.
-- **Config layer** — `internal/config/config.go`. YAML at `~/.claude-sync/config.yaml` (perms 0600). Supports both new unified `storage:` block and legacy R2-only top-level fields — `GetStorageConfig()` handles migration. `SyncPaths` defines what gets synced under `~/.claude/`; edit there to change the sync scope.
+- **Config layer** — `internal/config/config.go`. YAML at `~/.claude-sync/config.yaml` (perms 0600). Supports both new unified `storage:` block and legacy R2-only top-level fields — `GetStorageConfig()` handles migration. `SyncPaths` and `Exclude` define what gets synced; manage via `paths` subcommands (see below).
+- **Paths management** — `paths` subcommands in `main.go`. `Effective sync = sync_list − exclude_list`. `paths remove` is smart: default paths get an exclude entry (survives `paths reset`), custom paths are just deleted. `paths exclude <glob>` / `paths unexclude <glob>` manage sub-path glob filters. `paths add` removes conflicting exclude entries when re-enabling a removed default.
 
 ### On-disk layout
 
@@ -60,7 +61,15 @@ Layered, with a pluggable storage abstraction:
 
 ### MCP sync
 
-`~/.claude.json` holds global MCP server configs. Unlike regular sync, MCP uses a **three-way merge** (`internal/sync/mcp.go`) against a baseline stored in `SyncState.MCPBaseline`. On pull, local vs remote vs baseline are merged; conflicting server entries keep local. Paths inside MCP server commands/args are home-relative-normalized (`NormalizeMCPServers`) before upload and resolved back to absolute on pull. Remote key is fixed: `_external/mcp-servers.json.age`. Toggle via `mcp_sync: true` in config or the `--include-mcp` flag.
+`~/.claude.json` holds global MCP server configs. Unlike regular sync, MCP uses a **three-way merge** (`internal/sync/mcp.go`) against a baseline stored in `SyncState.MCPBaseline`. On pull, local vs remote vs baseline are merged; conflicting server entries keep local. Paths inside MCP server commands/args are home-relative-normalized (`NormalizeMCPServers`) before upload and resolved back to absolute on pull. Remote key is fixed: `_external/mcp-servers.json.age`.
+
+**Toggle options:**
+- `mcp enable` — writes `mcp_sync: true` to config **and immediately pushes current MCP state**. Subsequent `push`/`pull` auto-include MCP.
+- `mcp disable` — writes `mcp_sync: false` explicitly (visible in config). Use `--include-mcp` flag for one-off syncs.
+- `--include-mcp` flag on `push`/`pull` — one-time inclusion without changing the config.
+- `mcp status` — shows auto-sync state, local server count, and whether there are unpushed changes.
+
+**`MCPSync` field type:** `*bool` with `omitempty`. `nil` (field absent) = disabled (backward compat with old configs), `&true` = auto-sync enabled, `&false` = explicitly disabled and visible in config.
 
 ## Distribution & release
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ claude-sync reset       # Reset configuration (forgot passphrase)
 claude-sync migrate     # Convert legacy remote keys to portable path-mapped keys
 claude-sync update      # Update to latest version (verifies release checksums)
 claude-sync changelog   # Show release history
+claude-sync mcp         # Manage MCP server sync (status, enable, disable, push, pull)
+claude-sync paths       # Manage sync paths and sub-path filters
 claude-sync --help      # Show all commands
 ```
 
@@ -298,18 +300,61 @@ When enabled, hooks will:
 - **SessionStart**: Pull latest changes from remote
 - **Stop**: Push local changes to remote
 
-## Exclude Patterns
+## MCP Server Sync
 
-Skip specific files or directories during sync by adding exclude patterns to your config (`~/.claude-sync/config.yaml`):
+Sync your global MCP server configurations from `~/.claude.json` across devices.
 
-```yaml
-exclude:
-  - "*.tmp"
-  - "projects/*/node_modules/*"
-  - "projects/*/.git/*"
+```bash
+claude-sync mcp status          # Show auto-sync state, server count, pending changes
+claude-sync mcp enable          # Enable auto-sync + push current state now
+claude-sync mcp disable         # Disable auto-sync (use --include-mcp for one-off)
+claude-sync mcp push            # Push MCP configs manually
+claude-sync mcp pull            # Pull MCP configs manually
+claude-sync mcp list            # List locally configured MCP servers
 ```
 
-Patterns use glob syntax and are matched against paths relative to `~/.claude`.
+When auto-sync is enabled (`mcp enable`), every `push` and `pull` automatically includes MCP configs. MCP uses a three-way merge — conflicting server entries always keep the local version.
+
+```bash
+# One-off sync without changing settings
+claude-sync push --include-mcp
+claude-sync pull --include-mcp
+```
+
+## Sync Paths Management
+
+Control exactly which paths under `~/.claude/` are synced:
+
+```bash
+claude-sync paths                        # Show sync list and exclude filters
+claude-sync paths add my-notes           # Add a custom directory
+claude-sync paths remove history.jsonl   # Remove a path (default paths stay off after reset)
+claude-sync paths exclude "plugins/**/node_modules/**"   # Skip files inside a synced dir
+claude-sync paths unexclude "plugins/**/node_modules/**" # Remove a filter
+claude-sync paths edit                   # Interactive multi-select
+claude-sync paths reset                  # Restore factory defaults
+```
+
+**How it works:** `effective sync = sync_list − exclude_list`. Removing a default path (like `history.jsonl`) adds it to the exclude list so it stays off even after `paths reset`. Use `paths add` to re-enable it.
+
+`paths exclude` is for filtering **within** a synced directory (e.g. skip `node_modules`), not for removing top-level paths — use `paths remove` for that.
+
+## Exclude Patterns
+
+Sub-path filters skip specific files or directories inside an already-synced path:
+
+```bash
+# Skip node_modules inside plugins/
+claude-sync paths exclude "plugins/**/node_modules/**"
+
+# Skip .secret files in one project
+claude-sync paths exclude "projects/my-app/**.secret"
+
+# Remove a filter
+claude-sync paths unexclude "plugins/**/node_modules/**"
+```
+
+Patterns use glob syntax and are matched against paths relative to `~/.claude`. Supported forms: `dir/*` (direct children), `dir/**` (recursive), `**/*.ext` (any matching file).
 
 ## Shell Integration
 

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -1086,7 +1086,7 @@ func pushCmd() *cobra.Command {
 			}
 
 			// MCP sync if enabled
-			if includeMCP || cfg.MCPSync {
+			if includeMCP || (cfg.MCPSync != nil && *cfg.MCPSync) {
 				if err := runMCPPush(ctx, syncer); err != nil {
 					return err
 				}
@@ -1224,7 +1224,7 @@ Examples:
 			}
 
 			// MCP sync if enabled
-			if includeMCP || cfg.MCPSync {
+			if includeMCP || (cfg.MCPSync != nil && *cfg.MCPSync) {
 				if err := runMCPPull(ctx, syncer); err != nil {
 					return err
 				}
@@ -2664,6 +2664,7 @@ func mcpCmd() *cobra.Command {
 		Long: `Sync global MCP server configurations from ~/.claude.json across devices.`,
 	}
 	cmd.AddCommand(
+		mcpStatusCmd(),
 		mcpListCmd(),
 		mcpPushCmd(),
 		mcpPullCmd(),
@@ -2671,6 +2672,55 @@ func mcpCmd() *cobra.Command {
 		mcpDisableCmd(),
 	)
 	return cmd
+}
+
+func mcpStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show MCP sync settings and local server state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			// Auto-sync setting
+			autoSync := cfg.MCPSync != nil && *cfg.MCPSync
+			if autoSync {
+				fmt.Printf("  Auto-sync  %s✓ enabled%s  (included in every push/pull)\n", colorGreen, colorReset)
+			} else {
+				fmt.Printf("  Auto-sync  %s✗ disabled%s  (use --include-mcp or 'mcp push/pull')\n", colorDim, colorReset)
+			}
+
+			// Local server count + pending changes
+			syncer, err := sync.NewSyncer(cfg, quiet)
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			status, err := syncer.MCPStatus(ctx)
+			if err != nil {
+				return err
+			}
+
+			if status.ServerCount == 0 {
+				fmt.Printf("  Servers    %s0 servers%s in %s\n", colorDim, colorReset, config.ClaudeJSONPath())
+			} else {
+				fmt.Printf("  Servers    %d configured\n", status.ServerCount)
+			}
+
+			if status.HasChanges {
+				fmt.Printf("  Changes    %s● unpushed local changes%s\n", colorYellow, colorReset)
+			} else {
+				fmt.Printf("  Changes    %s✓ in sync%s\n", colorGreen, colorReset)
+			}
+
+			fmt.Printf("\n  %smcp enable%s   — auto-include in every push/pull\n", colorDim, colorReset)
+			fmt.Printf("  %smcp disable%s  — manual only\n", colorDim, colorReset)
+
+			return nil
+		},
+	}
 }
 
 func mcpListCmd() *cobra.Command {
@@ -2762,18 +2812,25 @@ func mcpPullCmd() *cobra.Command {
 func mcpEnableCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "enable",
-		Short: "Enable automatic MCP sync on every push/pull",
+		Short: "Enable automatic MCP sync on every push/pull (syncs now too)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return err
 			}
-			cfg.MCPSync = true
+			t := true
+			cfg.MCPSync = &t
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
-			fmt.Printf("%s✓%s MCP sync enabled. MCP servers will be synced automatically on every push/pull.\n", colorGreen, colorReset)
-			return nil
+			fmt.Printf("%s✓%s MCP auto-sync enabled.\n", colorGreen, colorReset)
+
+			syncer, err := sync.NewSyncer(cfg, quiet)
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			return runMCPPush(ctx, syncer)
 		},
 	}
 }
@@ -2787,7 +2844,8 @@ func mcpDisableCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cfg.MCPSync = false
+			f := false
+			cfg.MCPSync = &f
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
@@ -2817,8 +2875,69 @@ func runMCPPush(ctx context.Context, syncer *sync.Syncer) error {
 func pathsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "paths",
-		Short: "Manage sync paths",
-		Long:  "Manage which paths under ~/.claude/ are synced to cloud storage.\n\nUse subcommands to list, add, remove, edit, or reset sync paths,\nand to configure exclude patterns that skip certain files or directories.",
+		Short: "Manage sync paths and sub-path filters",
+		Long: `Manage which paths under ~/.claude/ are synced to cloud storage.
+
+HOW IT WORKS
+  Effective sync = sync_list − exclude_list
+
+  sync_list    built-in defaults + custom additions
+  exclude_list sub-path glob filters (block files inside a synced dir)
+
+  A path not in sync_list is never synced — no exclude needed.
+  A path in sync_list but matched by an exclude glob is skipped.
+
+REMOVING A DEFAULT PATH
+  Use 'paths remove'. It removes the path from sync_list AND adds it
+  to exclude so 'paths reset' never silently re-includes it.
+  Use 'paths add' to reverse this.
+
+EXCLUDE IS FOR SUB-PATH FILTERS ONLY
+  Use 'paths exclude' only to skip files or globs inside an
+  already-synced directory. Do not use it to remove a top-level path.
+
+    plugins/**/node_modules/**   skip node_modules inside plugins/
+    projects/my-app/**.secret    skip .secret files in one project
+
+  Glob syntax:
+    file.txt    exact relative path
+    dir/*       direct children of a directory
+    dir/**      all files recursively under a directory
+    **/*.ext    any matching file anywhere under a sync path
+
+SUBCOMMANDS
+  list                  Active defaults, removed defaults, custom, filters
+  add <path>            Add custom path or re-enable a removed default
+  remove <path>         Smart: default→excluded, custom→deleted  [-f]
+  exclude <glob>        Add a sub-path glob filter
+  unexclude <glob>      Remove a sub-path glob filter
+  edit                  Interactive multi-select for sync paths
+  reset                 Restore defaults, clear custom paths and filters [-f]
+
+EXAMPLES
+  # See full sync state
+  claude-sync paths
+
+  # Stop syncing history (stays off after reset too)
+  claude-sync paths remove history.jsonl
+
+  # Re-enable history
+  claude-sync paths add history.jsonl
+
+  # Add a custom directory
+  claude-sync paths add my-notes
+
+  # Skip node_modules inside plugins/
+  claude-sync paths exclude "plugins/**/node_modules/**"
+
+  # Remove that filter
+  claude-sync paths unexclude "plugins/**/node_modules/**"
+
+  # Reset to factory defaults
+  claude-sync paths reset`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPathsList()
+		},
 	}
 	cmd.AddCommand(
 		pathsListCmd(),
@@ -2827,14 +2946,16 @@ func pathsCmd() *cobra.Command {
 		pathsEditCmd(),
 		pathsResetCmd(),
 		pathsExcludeCmd(),
+		pathsUnexcludeCmd(),
 	)
 	return cmd
 }
 
 func pathsListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List configured sync paths",
+		Use:     "list",
+		Short:   "Show sync state: active, removed defaults, custom, filters",
+		Example: "  claude-sync paths list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPathsList()
 		},
@@ -2847,51 +2968,23 @@ func runPathsList() error {
 		return err
 	}
 
-	// Build a set of excluded base paths (strip /* and /**)
-	excludedBases := make(map[string]struct{}, len(cfg.Exclude))
-	for _, e := range cfg.Exclude {
-		base := strings.TrimSuffix(strings.TrimSuffix(e, "/**"), "/*")
-		excludedBases[base] = struct{}{}
-		excludedBases[e] = struct{}{} // also exact match (e.g. "history.jsonl")
-	}
-
-	// Remove sync paths that are covered by an exclude
-	allPaths := cfg.GetEffectiveSyncPaths()
-	var activePaths []string
-	var removedFromSync []string
-	for _, p := range allPaths {
-		if _, excluded := excludedBases[p]; excluded {
-			removedFromSync = append(removedFromSync, p)
-			continue
-		}
-		activePaths = append(activePaths, p)
-	}
-
-	if len(removedFromSync) > 0 {
-		cfg.SyncPaths = activePaths
-		if err := config.Save(cfg); err != nil {
-			return err
-		}
-		fmt.Printf("%s✓%s Removed from sync paths (covered by exclude): %s\n", colorGreen, colorReset, strings.Join(removedFromSync, ", "))
-	}
-
-	paths := activePaths
 	source := "default"
 	if len(cfg.SyncPaths) > 0 {
 		source = "config.yaml"
 	}
 
 	fmt.Printf("\n%sSync Paths%s (%s):\n", colorBold, colorReset, source)
-	for _, p := range paths {
+	for _, p := range cfg.GetEffectiveSyncPaths() {
 		fmt.Printf("  %s+%s %s\n", colorGreen, colorReset, p)
 	}
 
 	if len(cfg.Exclude) > 0 {
-		fmt.Printf("\n%sExclude Patterns%s:\n", colorBold, colorReset)
+		fmt.Printf("\n%sExclude%s:\n", colorBold, colorReset)
 		for _, p := range cfg.Exclude {
 			fmt.Printf("  %s-%s %s\n", colorYellow, colorReset, p)
 		}
 	}
+
 	fmt.Println()
 	return nil
 }
@@ -2899,8 +2992,17 @@ func runPathsList() error {
 func pathsAddCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add <path>",
-		Short: "Add a path to the sync list",
-		Args:  cobra.ExactArgs(1),
+		Short: "Add a path to sync, or re-enable a removed default",
+		Long: `Add a relative path under ~/.claude/ to the sync list.
+
+If the path was previously removed (and added to exclude), the
+conflicting exclude entry is automatically cleaned up so the path
+is actually synced again.
+
+The path does not have to exist yet — it is picked up on the next push.`,
+		Example: `  claude-sync paths add my-notes
+  claude-sync paths add history.jsonl`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
@@ -2909,18 +3011,17 @@ func pathsAddCmd() *cobra.Command {
 
 			newPath := args[0]
 
-			// Start from effective paths so we don't lose defaults when first customizing
 			effective := cfg.GetEffectiveSyncPaths()
 			for _, p := range effective {
 				if p == newPath {
-					fmt.Printf("%s! %s%s is already in the sync list\n", colorYellow, newPath, colorReset)
+					fmt.Printf("%s!%s %s is already in the sync list\n", colorYellow, colorReset, newPath)
 					return nil
 				}
 			}
 
 			claudeDir := config.ClaudeDir()
 			if _, err := os.Stat(filepath.Join(claudeDir, newPath)); os.IsNotExist(err) {
-				fmt.Printf("%s! %s%s does not exist under ~/.claude (adding anyway)\n", colorYellow, newPath, colorReset)
+				fmt.Printf("%s!%s %s does not exist under ~/.claude (adding anyway)\n", colorYellow, colorReset, newPath)
 			}
 
 			cfg.SyncPaths = append(effective, newPath)
@@ -2929,7 +3030,8 @@ func pathsAddCmd() *cobra.Command {
 			filtered := cfg.Exclude[:0:0]
 			removed := 0
 			for _, e := range cfg.Exclude {
-				if e == newPath || e == newPath+"/*" || e == newPath+"/**" {
+				base := strings.TrimSuffix(strings.TrimSuffix(e, "/**"), "/*")
+				if base == newPath || e == newPath {
 					removed++
 					continue
 				}
@@ -2940,9 +3042,9 @@ func pathsAddCmd() *cobra.Command {
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
-			fmt.Printf("%s✓%s Added %s to sync paths\n", colorGreen, colorReset, newPath)
+			fmt.Printf("%s✓%s Added %s to sync\n", colorGreen, colorReset, newPath)
 			if removed > 0 {
-				fmt.Printf("%s✓%s Removed %d conflicting exclude pattern(s) for %s\n", colorGreen, colorReset, removed, newPath)
+				fmt.Printf("%s✓%s Removed %d conflicting exclude(s) for %s\n", colorGreen, colorReset, removed, newPath)
 			}
 			return nil
 		},
@@ -2953,8 +3055,19 @@ func pathsRemoveCmd() *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
 		Use:   "remove <path>",
-		Short: "Remove a path from the sync list",
-		Args:  cobra.ExactArgs(1),
+		Short: "Remove a path from sync (smart: default→excluded, custom→deleted)",
+		Long: `Remove a path from the sync list.
+
+Default paths: removed from sync AND added to the exclude list so
+  that 'paths reset' never silently re-includes them.
+Custom paths:  simply deleted from the sync list — no exclude needed
+  since they were never part of the defaults.
+
+Use 'paths add <path>' to reverse a removal.
+Use --force (-f) to skip the confirmation prompt.`,
+		Example: `  claude-sync paths remove history.jsonl
+  claude-sync paths remove my-notes --force`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
@@ -2972,18 +3085,18 @@ func pathsRemoveCmd() *cobra.Command {
 				}
 			}
 			if !found {
-				fmt.Printf("%s! %s%s is not in the sync list\n", colorYellow, target, colorReset)
+				fmt.Printf("%s!%s %s is not in the sync list\n", colorYellow, colorReset, target)
 				return nil
 			}
 
 			if !force {
 				var confirm bool
 				prompt := &survey.Confirm{
-					Message: fmt.Sprintf("%q path listesinden kaldırılacak. Devam?", target),
+					Message: fmt.Sprintf("Remove %q from sync?", target),
 					Default: false,
 				}
 				if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
-					fmt.Println("  İptal edildi.")
+					fmt.Println("  Cancelled.")
 					return nil
 				}
 			}
@@ -2996,29 +3109,38 @@ func pathsRemoveCmd() *cobra.Command {
 			}
 			cfg.SyncPaths = newPaths
 
-			// Add to excludes so future default additions don't re-include this path
-			claudeDir := config.ClaudeDir()
-			excludePattern := target
-			if fi, err := os.Stat(filepath.Join(claudeDir, target)); err == nil && fi.IsDir() {
-				excludePattern = target + "/*"
+			// Only add to exclude if it's a default path (to survive reset)
+			defaultSet := make(map[string]struct{}, len(config.SyncPaths))
+			for _, p := range config.SyncPaths {
+				defaultSet[p] = struct{}{}
 			}
-			alreadyExcluded := false
-			for _, e := range cfg.Exclude {
-				if e == excludePattern {
-					alreadyExcluded = true
-					break
+
+			var addedExclude string
+			if _, isDefault := defaultSet[target]; isDefault {
+				claudeDir := config.ClaudeDir()
+				excludePattern := target
+				if fi, err := os.Stat(filepath.Join(claudeDir, target)); err == nil && fi.IsDir() {
+					excludePattern = target + "/*"
 				}
-			}
-			if !alreadyExcluded {
-				cfg.Exclude = append(cfg.Exclude, excludePattern)
+				alreadyExcluded := false
+				for _, e := range cfg.Exclude {
+					if e == excludePattern {
+						alreadyExcluded = true
+						break
+					}
+				}
+				if !alreadyExcluded {
+					cfg.Exclude = append(cfg.Exclude, excludePattern)
+					addedExclude = excludePattern
+				}
 			}
 
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
-			fmt.Printf("%s✓%s Removed %s from sync paths\n", colorGreen, colorReset, target)
-			if !alreadyExcluded {
-				fmt.Printf("%s✓%s Added %s to exclude patterns\n", colorGreen, colorReset, excludePattern)
+			fmt.Printf("%s✓%s Removed %s from sync\n", colorGreen, colorReset, target)
+			if addedExclude != "" {
+				fmt.Printf("%s✓%s Added exclude filter %s (survives reset)\n", colorGreen, colorReset, addedExclude)
 			}
 			return nil
 		},
@@ -3030,7 +3152,12 @@ func pathsRemoveCmd() *cobra.Command {
 func pathsEditCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "edit",
-		Short: "Interactively edit sync paths",
+		Short: "Interactive multi-select editor for sync paths",
+		Long: `Open an interactive list of all current sync paths.
+
+Space toggles a path; Enter saves. To permanently remove a default
+path (so it stays off after reset), use 'paths remove' instead.`,
+		Example: "  claude-sync paths edit",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
@@ -3041,7 +3168,7 @@ func pathsEditCmd() *cobra.Command {
 
 			var selected []string
 			prompt := &survey.MultiSelect{
-				Message: "Sync edilecek path'leri seç (space ile seç/kaldır):",
+				Message: "Select paths to sync (space to toggle, enter to save):",
 				Options: effective,
 				Default: effective,
 			}
@@ -3053,7 +3180,7 @@ func pathsEditCmd() *cobra.Command {
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
-			fmt.Printf("%s✓%s Sync paths güncellendi (%d path)\n", colorGreen, colorReset, len(selected))
+			fmt.Printf("%s✓%s Sync paths updated (%d paths)\n", colorGreen, colorReset, len(selected))
 			return nil
 		},
 	}
@@ -3063,7 +3190,18 @@ func pathsResetCmd() *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
 		Use:   "reset",
-		Short: "Reset sync paths to defaults",
+		Short: "Restore factory defaults, clear custom paths and filters",
+		Long: `Clear all custom sync paths, removed-default markers, and sub-path
+filters, restoring the built-in default set.
+
+Default sync paths:
+  CLAUDE.md, settings.json, settings.local.json, agents, commands,
+  skills, plugins, projects, plans, tasks, history.jsonl, rules,
+  workflows
+
+Use --force (-f) to skip the confirmation prompt.`,
+		Example: `  claude-sync paths reset
+  claude-sync paths reset --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
@@ -3073,11 +3211,11 @@ func pathsResetCmd() *cobra.Command {
 			if !force {
 				var confirm bool
 				prompt := &survey.Confirm{
-					Message: "sync_paths ve exclude ayarları sıfırlanacak, DefaultSyncPaths devreye girecek. Devam?",
+					Message: "Reset all sync paths and filters to factory defaults?",
 					Default: false,
 				}
 				if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
-					fmt.Println("  İptal edildi.")
+					fmt.Println("  Cancelled.")
 					return nil
 				}
 			}
@@ -3087,7 +3225,7 @@ func pathsResetCmd() *cobra.Command {
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
-			fmt.Printf("%s✓%s Sync paths sıfırlandı (DefaultSyncPaths aktif)\n", colorGreen, colorReset)
+			fmt.Printf("%s✓%s Sync paths reset to defaults\n", colorGreen, colorReset)
 			return nil
 		},
 	}
@@ -3096,55 +3234,47 @@ func pathsResetCmd() *cobra.Command {
 }
 
 func pathsExcludeCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "exclude",
-		Short: "Manage exclude patterns",
-	}
-	cmd.AddCommand(
-		pathsExcludeListCmd(),
-		pathsExcludeAddCmd(),
-		pathsExcludeRemoveCmd(),
-	)
-	return cmd
-}
-
-func pathsExcludeListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List exclude patterns",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load()
-			if err != nil {
-				return err
-			}
-			if len(cfg.Exclude) == 0 {
-				fmt.Println("  (exclude pattern yok)")
-				return nil
-			}
-			fmt.Printf("\n%sExclude Patterns%s:\n", colorBold, colorReset)
-			for _, p := range cfg.Exclude {
-				fmt.Printf("  %s-%s %s\n", colorYellow, colorReset, p)
-			}
-			fmt.Println()
-			return nil
-		},
-	}
-}
+		Use:   "exclude <glob>",
+		Short: "Add a sub-path glob filter inside a synced directory",
+		Long: `Add a glob pattern that blocks specific files or subdirectories
+inside an already-synced path.
 
-func pathsExcludeAddCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "add <pattern>",
-		Short: "Add an exclude pattern",
-		Args:  cobra.ExactArgs(1),
+Use this for filtering within a sync path — NOT for removing a top-level
+sync path. To stop syncing a whole path use 'paths remove'.
+
+Glob syntax:
+  dir/*              direct children of a directory
+  dir/**             all files recursively under a directory
+  **/*.ext           any matching file anywhere under a sync path
+  path/to/file.txt   exact relative file path inside a synced dir
+
+To remove a filter, use: paths unexclude <glob>`,
+		Example: `  # Skip node_modules inside plugins/
+  claude-sync paths exclude "plugins/**/node_modules/**"
+
+  # Skip .secret files in one project
+  claude-sync paths exclude "projects/my-app/**.secret"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return err
 			}
 			pattern := args[0]
+
+			// Guard: if pattern exactly matches an active sync path, guide to 'remove'
+			for _, p := range cfg.GetEffectiveSyncPaths() {
+				if p == pattern {
+					fmt.Printf("%s!%s %q is a top-level sync path — use 'paths remove %s' instead\n",
+						colorYellow, colorReset, pattern, pattern)
+					return nil
+				}
+			}
+
 			for _, p := range cfg.Exclude {
 				if p == pattern {
-					fmt.Printf("%s! %s%s zaten exclude listesinde\n", colorYellow, pattern, colorReset)
+					fmt.Printf("%s!%s %s is already in the filter list\n", colorYellow, colorReset, pattern)
 					return nil
 				}
 			}
@@ -3152,17 +3282,23 @@ func pathsExcludeAddCmd() *cobra.Command {
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
-			fmt.Printf("%s✓%s Exclude pattern eklendi: %s\n", colorGreen, colorReset, pattern)
+			fmt.Printf("%s✓%s Added sub-path filter: %s\n", colorGreen, colorReset, pattern)
 			return nil
 		},
 	}
 }
 
-func pathsExcludeRemoveCmd() *cobra.Command {
+func pathsUnexcludeCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "remove <pattern>",
-		Short: "Remove an exclude pattern",
-		Args:  cobra.ExactArgs(1),
+		Use:   "unexclude <glob>",
+		Short: "Remove a sub-path glob filter",
+		Long: `Remove a glob pattern from the sub-path filter list.
+
+If the pattern was added automatically by 'paths remove' (to mark a
+removed default), use 'paths add <path>' instead — it handles both
+re-adding the path to sync and removing the filter in one step.`,
+		Example: `  claude-sync paths unexclude "plugins/**/node_modules/**"`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
@@ -3179,14 +3315,14 @@ func pathsExcludeRemoveCmd() *cobra.Command {
 				newExclude = append(newExclude, p)
 			}
 			if !found {
-				fmt.Printf("%s! %s%s exclude listesinde bulunamadı\n", colorYellow, pattern, colorReset)
+				fmt.Printf("%s!%s %s not found in filter list\n", colorYellow, colorReset, pattern)
 				return nil
 			}
 			cfg.Exclude = newExclude
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
-			fmt.Printf("%s✓%s Exclude pattern kaldırıldı: %s\n", colorGreen, colorReset, pattern)
+			fmt.Printf("%s✓%s Removed filter: %s\n", colorGreen, colorReset, pattern)
 			return nil
 		},
 	}

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -70,6 +70,7 @@ func main() {
 		updateCmd(),
 		changelogCmd(),
 		mcpCmd(),
+		pathsCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {
@@ -283,7 +284,7 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 	}
 
 	// Step 1: Select provider
-	printStep(1, 3, "Select Storage Provider")
+	printStep(1, 4, "Select Storage Provider")
 	fmt.Println()
 
 	if provider == "" {
@@ -343,7 +344,7 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 
 	// Step 2: Encryption setup
 	fmt.Println()
-	printStep(2, 3, "Set Up Encryption")
+	printStep(2, 4, "Set Up Encryption")
 	printInfo("Files are encrypted with 'age' before upload.")
 	fmt.Println()
 
@@ -418,7 +419,7 @@ skipKeyGen:
 
 	// Step 3: Test Connection
 	fmt.Println()
-	printStep(3, 3, "Test Connection")
+	printStep(3, 4, "Test Connection")
 
 	exists, err := store.BucketExists(ctx)
 	if err != nil {
@@ -1135,7 +1136,7 @@ Examples:
 				}
 
 				if hasExisting && !force {
-					return handleFirstPullWithExistingFiles(ctx, syncer, dryRun)
+					return handleFirstPullWithExistingFiles(ctx, syncer, dryRun, cfg.GetEffectiveSyncPaths())
 				}
 			}
 
@@ -2225,7 +2226,7 @@ func hasExistingClaudeFiles(scope string) (bool, error) {
 
 // handleFirstPullWithExistingFiles handles the case where the user is pulling
 // for the first time but already has local files that could be overwritten
-func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, dryRun bool) error {
+func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, dryRun bool, syncPaths []string) error {
 	// Get preview of what would happen
 	preview, err := syncer.PreviewPull(ctx)
 	if err != nil {
@@ -2299,7 +2300,7 @@ func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, 
 	switch choice {
 	case 0:
 		// Backup and proceed
-		backupDir, err := createBackup(syncer.Scope())
+		backupDir, err := createBackup(syncPaths)
 		if err != nil {
 			return fmt.Errorf("failed to create backup: %w", err)
 		}
@@ -2320,7 +2321,7 @@ func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, 
 }
 
 // createBackup creates a backup of the current ~/.claude directory
-func createBackup(scope string) (string, error) {
+func createBackup(syncPaths []string) (string, error) {
 	claudeDir := config.ClaudeDir()
 	timestamp := time.Now().Format("20060102-150405")
 	backupDir := claudeDir + ".backup." + timestamp
@@ -2331,7 +2332,7 @@ func createBackup(scope string) (string, error) {
 	}
 
 	// Copy all syncable files to backup
-	files, err := sync.GetLocalFiles(claudeDir, config.ScopedSyncPaths(scope))
+	files, err := sync.GetLocalFiles(claudeDir, syncPaths)
 	if err != nil {
 		return "", fmt.Errorf("failed to list files: %w", err)
 	}
@@ -2771,6 +2772,322 @@ func runMCPPush(ctx context.Context, syncer *sync.Syncer) error {
 		}
 	}
 	return nil
+}
+
+func pathsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "paths",
+		Short: "Manage sync paths",
+		Long:  "List, add, remove, or reset the paths synced under ~/.claude.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPathsList()
+		},
+	}
+	cmd.AddCommand(
+		pathsListCmd(),
+		pathsAddCmd(),
+		pathsRemoveCmd(),
+		pathsEditCmd(),
+		pathsResetCmd(),
+		pathsExcludeCmd(),
+	)
+	return cmd
+}
+
+func pathsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured sync paths",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPathsList()
+		},
+	}
+}
+
+func runPathsList() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	paths := cfg.GetEffectiveSyncPaths()
+	source := "default"
+	if len(cfg.SyncPaths) > 0 {
+		source = "config.yaml"
+	}
+
+	fmt.Printf("\n%sSync Paths%s (%s):\n", colorBold, colorReset, source)
+	for _, p := range paths {
+		fmt.Printf("  %s+%s %s\n", colorGreen, colorReset, p)
+	}
+
+	if len(cfg.Exclude) > 0 {
+		fmt.Printf("\n%sExclude Patterns%s:\n", colorBold, colorReset)
+		for _, p := range cfg.Exclude {
+			fmt.Printf("  %s-%s %s\n", colorYellow, colorReset, p)
+		}
+	}
+	fmt.Println()
+	return nil
+}
+
+func pathsAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add <path>",
+		Short: "Add a path to the sync list",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			newPath := args[0]
+
+			// Start from effective paths so we don't lose defaults when first customizing
+			effective := cfg.GetEffectiveSyncPaths()
+			for _, p := range effective {
+				if p == newPath {
+					fmt.Printf("%s! %s%s is already in the sync list\n", colorYellow, newPath, colorReset)
+					return nil
+				}
+			}
+
+			claudeDir := config.ClaudeDir()
+			if _, err := os.Stat(filepath.Join(claudeDir, newPath)); os.IsNotExist(err) {
+				fmt.Printf("%s! %s%s does not exist under ~/.claude (adding anyway)\n", colorYellow, newPath, colorReset)
+			}
+
+			cfg.SyncPaths = append(effective, newPath)
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s Added %s to sync paths\n", colorGreen, colorReset, newPath)
+			return nil
+		},
+	}
+}
+
+func pathsRemoveCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "remove <path>",
+		Short: "Remove a path from the sync list",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			target := args[0]
+			effective := cfg.GetEffectiveSyncPaths()
+
+			found := false
+			for _, p := range effective {
+				if p == target {
+					found = true
+					break
+				}
+			}
+			if !found {
+				fmt.Printf("%s! %s%s is not in the sync list\n", colorYellow, target, colorReset)
+				return nil
+			}
+
+			if !force {
+				var confirm bool
+				prompt := &survey.Confirm{
+					Message: fmt.Sprintf("%q path listesinden kaldırılacak. Devam?", target),
+					Default: false,
+				}
+				if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
+					fmt.Println("  İptal edildi.")
+					return nil
+				}
+			}
+
+			newPaths := make([]string, 0, len(effective)-1)
+			for _, p := range effective {
+				if p != target {
+					newPaths = append(newPaths, p)
+				}
+			}
+			cfg.SyncPaths = newPaths
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s Removed %s from sync paths\n", colorGreen, colorReset, target)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation")
+	return cmd
+}
+
+func pathsEditCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "edit",
+		Short: "Interactively edit sync paths",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			effective := cfg.GetEffectiveSyncPaths()
+
+			var selected []string
+			prompt := &survey.MultiSelect{
+				Message: "Sync edilecek path'leri seç (space ile seç/kaldır):",
+				Options: effective,
+				Default: effective,
+			}
+			if err := survey.AskOne(prompt, &selected); err != nil {
+				return err
+			}
+
+			cfg.SyncPaths = selected
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s Sync paths güncellendi (%d path)\n", colorGreen, colorReset, len(selected))
+			return nil
+		},
+	}
+}
+
+func pathsResetCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset sync paths to defaults",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			if !force {
+				var confirm bool
+				prompt := &survey.Confirm{
+					Message: "sync_paths ve exclude ayarları sıfırlanacak, DefaultSyncPaths devreye girecek. Devam?",
+					Default: false,
+				}
+				if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
+					fmt.Println("  İptal edildi.")
+					return nil
+				}
+			}
+
+			cfg.SyncPaths = nil
+			cfg.Exclude = nil
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s Sync paths sıfırlandı (DefaultSyncPaths aktif)\n", colorGreen, colorReset)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation")
+	return cmd
+}
+
+func pathsExcludeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exclude",
+		Short: "Manage exclude patterns",
+	}
+	cmd.AddCommand(
+		pathsExcludeListCmd(),
+		pathsExcludeAddCmd(),
+		pathsExcludeRemoveCmd(),
+	)
+	return cmd
+}
+
+func pathsExcludeListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List exclude patterns",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if len(cfg.Exclude) == 0 {
+				fmt.Println("  (exclude pattern yok)")
+				return nil
+			}
+			fmt.Printf("\n%sExclude Patterns%s:\n", colorBold, colorReset)
+			for _, p := range cfg.Exclude {
+				fmt.Printf("  %s-%s %s\n", colorYellow, colorReset, p)
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+}
+
+func pathsExcludeAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add <pattern>",
+		Short: "Add an exclude pattern",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			pattern := args[0]
+			for _, p := range cfg.Exclude {
+				if p == pattern {
+					fmt.Printf("%s! %s%s zaten exclude listesinde\n", colorYellow, pattern, colorReset)
+					return nil
+				}
+			}
+			cfg.Exclude = append(cfg.Exclude, pattern)
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s Exclude pattern eklendi: %s\n", colorGreen, colorReset, pattern)
+			return nil
+		},
+	}
+}
+
+func pathsExcludeRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <pattern>",
+		Short: "Remove an exclude pattern",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			pattern := args[0]
+			newExclude := make([]string, 0, len(cfg.Exclude))
+			found := false
+			for _, p := range cfg.Exclude {
+				if p == pattern {
+					found = true
+					continue
+				}
+				newExclude = append(newExclude, p)
+			}
+			if !found {
+				fmt.Printf("%s! %s%s exclude listesinde bulunamadı\n", colorYellow, pattern, colorReset)
+				return nil
+			}
+			cfg.Exclude = newExclude
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s Exclude pattern kaldırıldı: %s\n", colorGreen, colorReset, pattern)
+			return nil
+		},
+	}
 }
 
 func runMCPPull(ctx context.Context, syncer *sync.Syncer) error {

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -2661,12 +2661,14 @@ func mcpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Manage MCP server sync",
-		Long:  `Sync global MCP server configurations from ~/.claude.json across devices.`,
+		Long: `Sync global MCP server configurations from ~/.claude.json across devices.`,
 	}
 	cmd.AddCommand(
 		mcpListCmd(),
 		mcpPushCmd(),
 		mcpPullCmd(),
+		mcpEnableCmd(),
+		mcpDisableCmd(),
 	)
 	return cmd
 }
@@ -2757,6 +2759,44 @@ func mcpPullCmd() *cobra.Command {
 	}
 }
 
+func mcpEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable",
+		Short: "Enable automatic MCP sync on every push/pull",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			cfg.MCPSync = true
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s MCP sync enabled. MCP servers will be synced automatically on every push/pull.\n", colorGreen, colorReset)
+			return nil
+		},
+	}
+}
+
+func mcpDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable",
+		Short: "Disable automatic MCP sync on every push/pull",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			cfg.MCPSync = false
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s MCP sync disabled. Use --include-mcp flag for one-time sync.\n", colorGreen, colorReset)
+			return nil
+		},
+	}
+}
+
 func runMCPPush(ctx context.Context, syncer *sync.Syncer) error {
 	result, err := syncer.PushMCP(ctx)
 	if err != nil {
@@ -2778,10 +2818,7 @@ func pathsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "paths",
 		Short: "Manage sync paths",
-		Long:  "List, add, remove, or reset the paths synced under ~/.claude.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPathsList()
-		},
+		Long:  "Manage which paths under ~/.claude/ are synced to cloud storage.\n\nUse subcommands to list, add, remove, edit, or reset sync paths,\nand to configure exclude patterns that skip certain files or directories.",
 	}
 	cmd.AddCommand(
 		pathsListCmd(),

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -2810,7 +2810,35 @@ func runPathsList() error {
 		return err
 	}
 
-	paths := cfg.GetEffectiveSyncPaths()
+	// Build a set of excluded base paths (strip /* and /**)
+	excludedBases := make(map[string]struct{}, len(cfg.Exclude))
+	for _, e := range cfg.Exclude {
+		base := strings.TrimSuffix(strings.TrimSuffix(e, "/**"), "/*")
+		excludedBases[base] = struct{}{}
+		excludedBases[e] = struct{}{} // also exact match (e.g. "history.jsonl")
+	}
+
+	// Remove sync paths that are covered by an exclude
+	allPaths := cfg.GetEffectiveSyncPaths()
+	var activePaths []string
+	var removedFromSync []string
+	for _, p := range allPaths {
+		if _, excluded := excludedBases[p]; excluded {
+			removedFromSync = append(removedFromSync, p)
+			continue
+		}
+		activePaths = append(activePaths, p)
+	}
+
+	if len(removedFromSync) > 0 {
+		cfg.SyncPaths = activePaths
+		if err := config.Save(cfg); err != nil {
+			return err
+		}
+		fmt.Printf("%s✓%s Removed from sync paths (covered by exclude): %s\n", colorGreen, colorReset, strings.Join(removedFromSync, ", "))
+	}
+
+	paths := activePaths
 	source := "default"
 	if len(cfg.SyncPaths) > 0 {
 		source = "config.yaml"

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -2859,10 +2859,26 @@ func pathsAddCmd() *cobra.Command {
 			}
 
 			cfg.SyncPaths = append(effective, newPath)
+
+			// Remove any exclude patterns that would block this path
+			filtered := cfg.Exclude[:0:0]
+			removed := 0
+			for _, e := range cfg.Exclude {
+				if e == newPath || e == newPath+"/*" || e == newPath+"/**" {
+					removed++
+					continue
+				}
+				filtered = append(filtered, e)
+			}
+			cfg.Exclude = filtered
+
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
 			fmt.Printf("%s✓%s Added %s to sync paths\n", colorGreen, colorReset, newPath)
+			if removed > 0 {
+				fmt.Printf("%s✓%s Removed %d conflicting exclude pattern(s) for %s\n", colorGreen, colorReset, removed, newPath)
+			}
 			return nil
 		},
 	}
@@ -2914,10 +2930,31 @@ func pathsRemoveCmd() *cobra.Command {
 				}
 			}
 			cfg.SyncPaths = newPaths
+
+			// Add to excludes so future default additions don't re-include this path
+			claudeDir := config.ClaudeDir()
+			excludePattern := target
+			if fi, err := os.Stat(filepath.Join(claudeDir, target)); err == nil && fi.IsDir() {
+				excludePattern = target + "/*"
+			}
+			alreadyExcluded := false
+			for _, e := range cfg.Exclude {
+				if e == excludePattern {
+					alreadyExcluded = true
+					break
+				}
+			}
+			if !alreadyExcluded {
+				cfg.Exclude = append(cfg.Exclude, excludePattern)
+			}
+
 			if err := config.Save(cfg); err != nil {
 				return err
 			}
 			fmt.Printf("%s✓%s Removed %s from sync paths\n", colorGreen, colorReset, target)
+			if !alreadyExcluded {
+				fmt.Printf("%s✓%s Added %s to exclude patterns\n", colorGreen, colorReset, excludePattern)
+			}
 			return nil
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	// or "sessions" (portable conversation data only). See ScopedSyncPaths.
 	Scope string `yaml:"scope,omitempty"`
 
+	// SyncPaths overrides the scope-based path set when non-empty.
+	SyncPaths []string `yaml:"sync_paths,omitempty"`
+
 	// MCPSync enables syncing MCP server configs from ~/.claude.json
 	MCPSync bool `yaml:"mcp_sync,omitempty"`
 
@@ -86,6 +89,7 @@ var SyncPaths = []string{
 	"tasks",
 	"history.jsonl",
 	"rules",
+	"workflows",
 }
 
 // SessionSyncPaths is the subset synced in the "sessions" scope: portable,
@@ -234,6 +238,14 @@ func (c *Config) GetStorageConfig() *storage.StorageConfig {
 // IsLegacyConfig returns true if using the legacy R2-only config format
 func (c *Config) IsLegacyConfig() bool {
 	return c.Storage == nil && c.AccountID != ""
+}
+
+// GetEffectiveSyncPaths returns the user-configured sync paths if set, otherwise the scope-based set.
+func (c *Config) GetEffectiveSyncPaths() []string {
+	if len(c.SyncPaths) > 0 {
+		return c.SyncPaths
+	}
+	return ScopedSyncPaths(c.Scope)
 }
 
 // IsExcluded returns true if the given relative path matches any exclude pattern.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,8 +51,10 @@ type Config struct {
 	// SyncPaths overrides the scope-based path set when non-empty.
 	SyncPaths []string `yaml:"sync_paths,omitempty"`
 
-	// MCPSync enables syncing MCP server configs from ~/.claude.json
-	MCPSync bool `yaml:"mcp_sync,omitempty"`
+	// MCPSync enables syncing MCP server configs from ~/.claude.json.
+	// Pointer so nil (field absent) reads as disabled without writing "false"
+	// to existing configs; disable explicitly writes false so the state is visible.
+	MCPSync *bool `yaml:"mcp_sync,omitempty"`
 
 	// PathMap maps local directory prefixes to shared token names so project
 	// sessions stay resumable across devices with different layouts.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -232,6 +232,26 @@ func TestSyncPaths(t *testing.T) {
 	}
 }
 
+func TestGetEffectiveSyncPaths(t *testing.T) {
+	// Empty SyncPaths → returns SyncPaths
+	cfg := &Config{}
+	got := cfg.GetEffectiveSyncPaths()
+	if len(got) != len(SyncPaths) {
+		t.Errorf("expected %d paths, got %d", len(SyncPaths), len(got))
+	}
+
+	// Custom SyncPaths → returns custom list
+	custom := []string{"CLAUDE.md", "settings.json"}
+	cfg.SyncPaths = custom
+	got = cfg.GetEffectiveSyncPaths()
+	if len(got) != len(custom) {
+		t.Errorf("expected %d paths, got %d", len(custom), len(got))
+	}
+	if got[0] != "CLAUDE.md" || got[1] != "settings.json" {
+		t.Errorf("unexpected paths: %v", got)
+	}
+}
+
 func TestClaudeJSONPath(t *testing.T) {
 	path := ClaudeJSONPath()
 	if path == "" {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -132,10 +132,10 @@ func (s *Syncer) isExcluded(relPath string) bool {
 	return s.cfg.IsExcluded(relPath)
 }
 
-// syncPaths returns the set of ~/.claude paths to sync, honoring the
-// configured scope ("full" by default, or "sessions" for portable data only).
+// syncPaths returns the set of ~/.claude paths to sync, honoring sync_paths
+// override first, then the configured scope ("full" by default, or "sessions").
 func (s *Syncer) syncPaths() []string {
-	return config.ScopedSyncPaths(s.cfg.Scope)
+	return s.cfg.GetEffectiveSyncPaths()
 }
 
 // Scope returns the configured sync scope (empty means the default "full").
@@ -155,6 +155,7 @@ func (s *Syncer) Push(ctx context.Context) (*SyncResult, error) {
 	s.progress(ProgressEvent{Action: "scan", Path: "Detecting changes..."})
 
 	changes, err := s.state.DetectChanges(s.claudeDir, s.syncPaths(), s.isExcluded)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect changes: %w", err)
 	}
@@ -271,6 +272,7 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 
 	// Get current local files
 	localFiles, err := GetLocalFiles(s.claudeDir, s.syncPaths(), s.isExcluded)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -375,6 +377,7 @@ func (s *Syncer) Pull(ctx context.Context) (*SyncResult, error) {
 
 func (s *Syncer) Status(ctx context.Context) ([]FileChange, error) {
 	return s.state.DetectChanges(s.claudeDir, s.syncPaths(), s.isExcluded)
+
 }
 
 func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
@@ -573,6 +576,7 @@ func (s *Syncer) PreviewPull(ctx context.Context) (*PullPreview, error) {
 
 	// Get current local files
 	localFiles, err := GetLocalFiles(s.claudeDir, s.syncPaths(), s.isExcluded)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}
@@ -652,6 +656,7 @@ func (s *Syncer) Diff(ctx context.Context) ([]DiffEntry, error) {
 
 	// Get local files
 	localFiles, err := GetLocalFiles(s.claudeDir, s.syncPaths(), s.isExcluded)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local files: %w", err)
 	}


### PR DESCRIPTION
This PR redesigns two areas: sync path management and MCP sync UX.

paths commands redesigned
exclude is no longer a nested exclude list/add/remove subcommand group — it's now a flat paths exclude <glob> / paths unexclude <glob>.

Smart remove: paths remove now detects whether the target is a default or custom path:

Default path (e.g. history.jsonl) → removed from sync list + added to exclude → stays off after paths reset
Custom path → simply deleted from sync list, exclude untouched
paths add automatically cleans up conflicting exclude entries when re-enabling a removed path.

paths (no args) now shows the list directly:


Sync Paths (default):
  + CLAUDE.md
  + plugins
  ...

Exclude:
  - plugins/**/node_modules/**
MCP sync improvements
mcp enable no longer just writes a flag to config — it also immediately runs an MCP push. Enabling auto-sync syncs your current state right away; subsequent push/pull runs include MCP automatically.

mcp disable now writes mcp_sync: false explicitly instead of removing the field. Existing configs without the field unmarshal to nil → disabled, preserving backward compatibility (*bool + omitempty).

mcp status is a new command showing the current setting, server count, and whether there are unpushed local changes:


  Auto-sync  ✓ enabled  (included in every push/pull)
  Servers    5 configured
  Changes    ✓ in sync
Docs
CLAUDE.md and README.md updated to document the paths management architecture, MCP *bool field semantics, new commands, and usage examples.