### PR TITLE
feat: improve MCP sync UX (enable/disable/status, *bool semantics)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,15 @@ Layered, with a pluggable storage abstraction:
 
 ### MCP sync
 
-`~/.claude.json` holds global MCP server configs. Unlike regular sync, MCP uses a **three-way merge** (`internal/sync/mcp.go`) against a baseline stored in `SyncState.MCPBaseline`. On pull, local vs remote vs baseline are merged; conflicting server entries keep local. Paths inside MCP server commands/args are home-relative-normalized (`NormalizeMCPServers`) before upload and resolved back to absolute on pull. Remote key is fixed: `_external/mcp-servers.json.age`. Toggle via `mcp_sync: true` in config or the `--include-mcp` flag.
+`~/.claude.json` holds global MCP server configs. Unlike regular sync, MCP uses a **three-way merge** (`internal/sync/mcp.go`) against a baseline stored in `SyncState.MCPBaseline`. On pull, local vs remote vs baseline are merged; conflicting server entries keep local. Paths inside MCP server commands/args are home-relative-normalized (`NormalizeMCPServers`) before upload and resolved back to absolute on pull. Remote key is fixed: `_external/mcp-servers.json.age`.
+
+**Toggle options:**
+- `mcp enable` — writes `mcp_sync: true` to config **and immediately pushes current MCP state**. Subsequent `push`/`pull` auto-include MCP.
+- `mcp disable` — writes `mcp_sync: false` explicitly (visible in config). Use `--include-mcp` flag for one-off syncs.
+- `--include-mcp` flag on `push`/`pull` — one-time inclusion without changing the config.
+- `mcp status` — shows auto-sync state, local server count, and whether there are unpushed changes.
+
+**`MCPSync` field type:** `*bool` with `omitempty`. `nil` (field absent) = disabled (backward compat with old configs), `&true` = auto-sync enabled, `&false` = explicitly disabled and visible in config.
 
 ## Distribution & release
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ claude-sync reset       # Reset configuration (forgot passphrase)
 claude-sync migrate     # Convert legacy remote keys to portable path-mapped keys
 claude-sync update      # Update to latest version (verifies release checksums)
 claude-sync changelog   # Show release history
+claude-sync mcp         # Manage MCP server sync (status, enable, disable, push, pull)
 claude-sync --help      # Show all commands
 ```
 
@@ -283,6 +284,27 @@ claude-sync update           # Download and install latest version
 ```bash
 claude-sync changelog            # Show recent releases
 claude-sync changelog --limit 5  # Show last 5 releases
+```
+
+## MCP Server Sync
+
+Sync your global MCP server configurations from `~/.claude.json` across devices.
+
+```bash
+claude-sync mcp status          # Show auto-sync state, server count, pending changes
+claude-sync mcp enable          # Enable auto-sync + push current state now
+claude-sync mcp disable         # Disable auto-sync (use --include-mcp for one-off)
+claude-sync mcp push            # Push MCP configs manually
+claude-sync mcp pull            # Pull MCP configs manually
+claude-sync mcp list            # List locally configured MCP servers
+```
+
+When auto-sync is enabled (`mcp enable`), every `push` and `pull` automatically includes MCP configs. MCP uses a three-way merge — conflicting server entries always keep the local version.
+
+```bash
+# One-off sync without changing settings
+claude-sync push --include-mcp
+claude-sync pull --include-mcp
 ```
 
 ## Exclude Patterns

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -1085,7 +1085,7 @@ func pushCmd() *cobra.Command {
 			}
 
 			// MCP sync if enabled
-			if includeMCP || cfg.MCPSync {
+			if includeMCP || (cfg.MCPSync != nil && *cfg.MCPSync) {
 				if err := runMCPPush(ctx, syncer); err != nil {
 					return err
 				}
@@ -1223,7 +1223,7 @@ Examples:
 			}
 
 			// MCP sync if enabled
-			if includeMCP || cfg.MCPSync {
+			if includeMCP || (cfg.MCPSync != nil && *cfg.MCPSync) {
 				if err := runMCPPull(ctx, syncer); err != nil {
 					return err
 				}
@@ -2663,11 +2663,63 @@ func mcpCmd() *cobra.Command {
 		Long:  `Sync global MCP server configurations from ~/.claude.json across devices.`,
 	}
 	cmd.AddCommand(
+		mcpStatusCmd(),
 		mcpListCmd(),
 		mcpPushCmd(),
 		mcpPullCmd(),
+		mcpEnableCmd(),
+		mcpDisableCmd(),
 	)
 	return cmd
+}
+
+func mcpStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show MCP sync settings and local server state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			// Auto-sync setting
+			autoSync := cfg.MCPSync != nil && *cfg.MCPSync
+			if autoSync {
+				fmt.Printf("  Auto-sync  %s✓ enabled%s  (included in every push/pull)\n", colorGreen, colorReset)
+			} else {
+				fmt.Printf("  Auto-sync  %s✗ disabled%s  (use --include-mcp or 'mcp push/pull')\n", colorDim, colorReset)
+			}
+
+			// Local server count + pending changes
+			syncer, err := sync.NewSyncer(cfg, quiet)
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			status, err := syncer.MCPStatus(ctx)
+			if err != nil {
+				return err
+			}
+
+			if status.ServerCount == 0 {
+				fmt.Printf("  Servers    %s0 servers%s in %s\n", colorDim, colorReset, config.ClaudeJSONPath())
+			} else {
+				fmt.Printf("  Servers    %d configured\n", status.ServerCount)
+			}
+
+			if status.HasChanges {
+				fmt.Printf("  Changes    %s● unpushed local changes%s\n", colorYellow, colorReset)
+			} else {
+				fmt.Printf("  Changes    %s✓ in sync%s\n", colorGreen, colorReset)
+			}
+
+			fmt.Printf("\n  %smcp enable%s   — auto-include in every push/pull\n", colorDim, colorReset)
+			fmt.Printf("  %smcp disable%s  — manual only\n", colorDim, colorReset)
+
+			return nil
+		},
+	}
 }
 
 func mcpListCmd() *cobra.Command {
@@ -2752,6 +2804,52 @@ func mcpPullCmd() *cobra.Command {
 
 			ctx := context.Background()
 			return runMCPPull(ctx, syncer)
+		},
+	}
+}
+
+func mcpEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable",
+		Short: "Enable automatic MCP sync on every push/pull (syncs now too)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			t := true
+			cfg.MCPSync = &t
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s MCP auto-sync enabled.\n", colorGreen, colorReset)
+
+			syncer, err := sync.NewSyncer(cfg, quiet)
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			return runMCPPush(ctx, syncer)
+		},
+	}
+}
+
+func mcpDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable",
+		Short: "Disable automatic MCP sync on every push/pull",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			f := false
+			cfg.MCPSync = &f
+			if err := config.Save(cfg); err != nil {
+				return err
+			}
+			fmt.Printf("%s✓%s MCP sync disabled. Use --include-mcp flag for one-time sync.\n", colorGreen, colorReset)
+			return nil
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,8 +49,10 @@ type Config struct {
 	// or "sessions" (portable conversation data only). See ScopedSyncPaths.
 	Scope string `yaml:"scope,omitempty"`
 
-	// MCPSync enables syncing MCP server configs from ~/.claude.json
-	MCPSync bool `yaml:"mcp_sync,omitempty"`
+	// MCPSync enables syncing MCP server configs from ~/.claude.json.
+	// Pointer so nil (field absent) reads as disabled without writing "false"
+	// to existing configs; disable explicitly writes false so the state is visible.
+	MCPSync *bool `yaml:"mcp_sync,omitempty"`
 
 	// PathMap maps local directory prefixes to shared token names so project
 	// sessions stay resumable across devices with different layouts.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -312,12 +312,13 @@ func TestConfigSaveAndLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	mcpEnabled := true
 	cfg := &Config{
 		EncryptionKey: "~/.claude-sync/age-key.txt",
 		Bucket:        "test-bucket",
 		AccountID:     "test-account",
 		Exclude:       []string{"*.tmp", "cache/**"},
-		MCPSync:       true,
+		MCPSync:       &mcpEnabled,
 	}
 
 	// Write config manually to test Load


### PR DESCRIPTION
This is one of two focused PRs that replace #40 (which bundled paths + MCP + docs into a single 688-line change). This PR contains **only** the MCP sync UX work; the paths redesign is a separate PR.

## What changed

New `mcp` subcommands:

- `mcp status` — shows auto-sync state, configured server count, and whether there are unpushed local changes.
- `mcp enable` — writes `mcp_sync: true` **and immediately pushes** the current MCP state, so enabling auto-sync syncs right away. Subsequent `push`/`pull` auto-include MCP.
- `mcp disable` — writes `mcp_sync: false` explicitly so the disabled state is visible in config.

`--include-mcp` on `push`/`pull` still works for one-off syncs without changing config.

## On the `*bool` design (re: review feedback on #40)

The `MCPSync` config field becomes `*bool` with `omitempty`. This was a deliberate choice over a config migration, and I think it's the simpler option here:

- **nil** (field absent) reads as **disabled** — every existing config keeps working untouched, so there is **no migration step** and no risk of rewriting users' config files on load.
- **`&true`** = auto-sync enabled.
- **`&false`** = explicitly disabled, written to config so the state is **visible/inspectable** (a plain `bool` + `omitempty` can't distinguish "off" from "unset").

So the three states (unset / on / off) are encoded in the type itself. A migration would have to detect old configs and rewrite them on first load to achieve the same backward compatibility; the pointer keeps that logic out of the load path entirely.

## Docs

`CLAUDE.md` and `README.md` updated to document the new `mcp` subcommands and the `*bool` field semantics.

## Scope

Diff is limited to MCP only: `cmd/claude-sync/main.go` (3 new subcommands + 2 push/pull check sites), `internal/config/config.go` (field type), `internal/config/config_test.go` (adapt existing test to the new type), and the MCP doc sections.