### PR TITLE
fix(webdav): fall back to Depth: 1 walk when server rejects Depth: infinity

### DIFF
--- a/internal/storage/webdav/webdav.go
+++ b/internal/storage/webdav/webdav.go
@@ -145,17 +145,8 @@ func (c *Client) DeleteBatch(ctx context.Context, keys []string) error {
 	return nil
 }
 
-// List returns all objects under the given prefix using PROPFIND.
-func (c *Client) List(ctx context.Context, prefix string) ([]storage.ObjectInfo, error) {
-	url := c.collectionURL()
-	if prefix != "" {
-		url = c.collectionURL() + prefix
-		if !strings.HasSuffix(url, "/") {
-			url += "/"
-		}
-	}
-
-	propfindBody := `<?xml version="1.0" encoding="UTF-8"?>
+// propfindListBody is the PROPFIND request body used to enumerate objects.
+const propfindListBody = `<?xml version="1.0" encoding="UTF-8"?>
 <d:propfind xmlns:d="DAV:">
   <d:prop>
     <d:getcontentlength/>
@@ -165,52 +156,144 @@ func (c *Client) List(ctx context.Context, prefix string) ([]storage.ObjectInfo,
   </d:prop>
 </d:propfind>`
 
-	resp, err := c.doRequest(ctx, "PROPFIND", url, strings.NewReader(propfindBody), map[string]string{
-		"Content-Type": "application/xml",
-		"Depth":        "infinity",
-	})
+// List returns all objects under the given prefix using PROPFIND.
+//
+// It first attempts a single Depth: infinity request, which Nextcloud and
+// ownCloud support. Many other servers — notably Synology's WebDAV Server and
+// Apache mod_dav with its default DavDepthInfinity off — reject infinite-depth
+// PROPFIND with 403/405/501. In that case we fall back to walking the tree with
+// Depth: 1 requests, which every WebDAV server supports.
+func (c *Client) List(ctx context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	startURL := c.collectionURL()
+	if prefix != "" {
+		startURL = c.collectionURL() + prefix
+		if !strings.HasSuffix(startURL, "/") {
+			startURL += "/"
+		}
+	}
+
+	responses, status, err := c.propfind(ctx, startURL, "infinity")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list objects: %w", err)
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
+	switch {
+	case status == http.StatusNotFound:
 		return nil, nil
+	case status == 207:
+		return c.collectObjects(responses), nil
+	case infinityUnsupported(status):
+		// Server refuses Depth: infinity — walk the tree one level at a time.
+		return c.listRecursive(ctx, startURL)
+	default:
+		return nil, fmt.Errorf("failed to list objects: HTTP %d", status)
+	}
+}
+
+// infinityUnsupported reports whether a status code indicates the server
+// rejected a Depth: infinity PROPFIND (as opposed to a genuine error).
+func infinityUnsupported(status int) bool {
+	switch status {
+	case http.StatusForbidden, http.StatusMethodNotAllowed, http.StatusNotImplemented, http.StatusBadRequest:
+		return true
+	default:
+		return false
+	}
+}
+
+// listRecursive walks the collection tree using Depth: 1 PROPFIND requests,
+// for servers that reject Depth: infinity. Directories are visited breadth-first.
+func (c *Client) listRecursive(ctx context.Context, startURL string) ([]storage.ObjectInfo, error) {
+	var objects []storage.ObjectInfo
+	queue := []string{startURL}
+	visited := map[string]bool{}
+
+	for len(queue) > 0 {
+		dirURL := queue[0]
+		queue = queue[1:]
+		if visited[dirURL] {
+			continue
+		}
+		visited[dirURL] = true
+
+		responses, status, err := c.propfind(ctx, dirURL, "1")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list objects: %w", err)
+		}
+		if status == http.StatusNotFound {
+			continue
+		}
+		if status != 207 {
+			return nil, fmt.Errorf("failed to list objects: HTTP %d", status)
+		}
+
+		for _, r := range responses {
+			key := c.hrefToKey(r.Href)
+			if key == "" {
+				continue // the collection referencing itself
+			}
+			if r.IsCollection {
+				childURL := c.collectionURL() + key
+				if !strings.HasSuffix(childURL, "/") {
+					childURL += "/"
+				}
+				queue = append(queue, childURL)
+				continue
+			}
+			objects = append(objects, storage.ObjectInfo{
+				Key:          key,
+				Size:         r.ContentLength,
+				LastModified: r.LastModified,
+				ETag:         r.ETag,
+			})
+		}
 	}
 
+	return objects, nil
+}
+
+// propfind issues a PROPFIND at the given depth and returns the parsed entries
+// together with the HTTP status code. A non-207 status yields (nil, status, nil)
+// so callers can decide how to react without treating it as a transport error.
+func (c *Client) propfind(ctx context.Context, url, depth string) ([]parsedResponse, int, error) {
+	resp, err := c.doRequest(ctx, "PROPFIND", url, strings.NewReader(propfindListBody), map[string]string{
+		"Content-Type": "application/xml",
+		"Depth":        depth,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 207 {
-		return nil, fmt.Errorf("failed to list objects: HTTP %d", resp.StatusCode)
+		return nil, resp.StatusCode, nil
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read PROPFIND response: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("failed to read PROPFIND response: %w", err)
 	}
 
 	responses, err := parsePropfindResponse(body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse PROPFIND response: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("failed to parse PROPFIND response: %w", err)
 	}
 
-	collectionBase := c.collectionURL()
+	return responses, resp.StatusCode, nil
+}
+
+// collectObjects turns PROPFIND entries into ObjectInfos, dropping collections
+// and the self-reference of the listed directory.
+func (c *Client) collectObjects(responses []parsedResponse) []storage.ObjectInfo {
 	var objects []storage.ObjectInfo
 	for _, r := range responses {
 		if r.IsCollection {
 			continue
 		}
-
-		key := r.Href
-		if idx := strings.Index(key, c.pathPrefix+"/"); idx >= 0 {
-			key = key[idx+len(c.pathPrefix)+1:]
-		} else {
-			key = strings.TrimPrefix(key, collectionBase)
-		}
-		key = strings.TrimLeft(key, "/")
-
+		key := c.hrefToKey(r.Href)
 		if key == "" {
 			continue
 		}
-
 		objects = append(objects, storage.ObjectInfo{
 			Key:          key,
 			Size:         r.ContentLength,
@@ -218,23 +301,24 @@ func (c *Client) List(ctx context.Context, prefix string) ([]storage.ObjectInfo,
 			ETag:         r.ETag,
 		})
 	}
+	return objects
+}
 
-	return objects, nil
+// hrefToKey converts a PROPFIND href into a storage key relative to the
+// configured path prefix.
+func (c *Client) hrefToKey(href string) string {
+	key := href
+	if idx := strings.Index(key, c.pathPrefix+"/"); c.pathPrefix != "" && idx >= 0 {
+		key = key[idx+len(c.pathPrefix)+1:]
+	} else {
+		key = strings.TrimPrefix(key, c.collectionURL())
+	}
+	return strings.TrimLeft(key, "/")
 }
 
 // Head returns metadata for the given key without downloading content.
 func (c *Client) Head(ctx context.Context, key string) (*storage.ObjectInfo, error) {
-	propfindBody := `<?xml version="1.0" encoding="UTF-8"?>
-<d:propfind xmlns:d="DAV:">
-  <d:prop>
-    <d:getcontentlength/>
-    <d:getlastmodified/>
-    <d:getetag/>
-    <d:resourcetype/>
-  </d:prop>
-</d:propfind>`
-
-	resp, err := c.doRequest(ctx, "PROPFIND", c.fullURL(key), strings.NewReader(propfindBody), map[string]string{
+	resp, err := c.doRequest(ctx, "PROPFIND", c.fullURL(key), strings.NewReader(propfindListBody), map[string]string{
 		"Content-Type": "application/xml",
 		"Depth":        "0",
 	})

--- a/internal/storage/webdav/webdav_test.go
+++ b/internal/storage/webdav/webdav_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 
@@ -586,5 +587,159 @@ func TestEnsureParentDirsNoParent(t *testing.T) {
 	err := client.ensureParentDirs(context.Background(), "file.age")
 	if err != nil {
 		t.Errorf("ensureParentDirs() error = %v", err)
+	}
+}
+
+// multistatusFor builds a 207 PROPFIND body for a Depth: 1 listing of dir:
+// the self-reference plus the given child files and child collections.
+func multistatusFor(dir string, files, dirs []string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><d:multistatus xmlns:d="DAV:">`)
+	// self
+	b.WriteString(`<d:response><d:href>` + dir + `</d:href><d:propstat><d:prop>` +
+		`<d:resourcetype><d:collection/></d:resourcetype></d:prop>` +
+		`<d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>`)
+	for _, f := range files {
+		b.WriteString(`<d:response><d:href>` + dir + f + `</d:href><d:propstat><d:prop>` +
+			`<d:resourcetype/><d:getcontentlength>10</d:getcontentlength>` +
+			`<d:getlastmodified>Mon, 14 Apr 2025 10:00:00 GMT</d:getlastmodified>` +
+			`<d:getetag>"e-` + f + `"</d:getetag></d:prop>` +
+			`<d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>`)
+	}
+	for _, d := range dirs {
+		b.WriteString(`<d:response><d:href>` + dir + d + `/</d:href><d:propstat><d:prop>` +
+			`<d:resourcetype><d:collection/></d:resourcetype></d:prop>` +
+			`<d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>`)
+	}
+	b.WriteString(`</d:multistatus>`)
+	return b.String()
+}
+
+// TestListDepthInfinityFallback verifies that when a server rejects a
+// Depth: infinity PROPFIND (as Synology WebDAV Server and Apache mod_dav do),
+// List falls back to a recursive Depth: 1 walk and still enumerates every file.
+func TestListDepthInfinityFallback(t *testing.T) {
+	const prefix = "claude-sync"
+
+	// Tree under /claude-sync/:
+	//   settings.enc
+	//   sessions/a.enc
+	//   sessions/nested/b.enc
+	tree := map[string]string{
+		"/claude-sync/":                 multistatusFor("/claude-sync/", []string{"settings.enc"}, []string{"sessions"}),
+		"/claude-sync/sessions/":        multistatusFor("/claude-sync/sessions/", []string{"a.enc"}, []string{"nested"}),
+		"/claude-sync/sessions/nested/": multistatusFor("/claude-sync/sessions/nested/", []string{"b.enc"}, nil),
+	}
+
+	var infinityAttempts, depth1Requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PROPFIND" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get("Depth") == "infinity" {
+			infinityAttempts++
+			// Mimic Synology / Apache DavDepthInfinity off.
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		depth1Requests++
+		body, ok := tree[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(207)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	c, err := New(&storage.StorageConfig{
+		WebDAVURL:      server.URL,
+		PathPrefix:     prefix,
+		WebDAVUsername: "u",
+		WebDAVPassword: "p",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	objs, err := c.List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if infinityAttempts != 1 {
+		t.Errorf("expected exactly 1 Depth: infinity attempt, got %d", infinityAttempts)
+	}
+	if depth1Requests != 3 {
+		t.Errorf("expected 3 Depth: 1 requests (one per collection), got %d", depth1Requests)
+	}
+
+	got := make([]string, 0, len(objs))
+	for _, o := range objs {
+		got = append(got, o.Key)
+	}
+	sort.Strings(got)
+
+	want := []string{"sessions/a.enc", "sessions/nested/b.enc", "settings.enc"}
+	if len(got) != len(want) {
+		t.Fatalf("expected keys %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected keys %v, got %v", want, got)
+		}
+	}
+}
+
+// TestListDepthInfinitySuccess verifies the fast path: a server that honors
+// Depth: infinity is listed in a single request with no fallback walk.
+func TestListDepthInfinitySuccess(t *testing.T) {
+	const prefix = "claude-sync"
+
+	full := `<?xml version="1.0"?><d:multistatus xmlns:d="DAV:">` +
+		`<d:response><d:href>/claude-sync/</d:href><d:propstat><d:prop>` +
+		`<d:resourcetype><d:collection/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>` +
+		`<d:response><d:href>/claude-sync/settings.enc</d:href><d:propstat><d:prop>` +
+		`<d:resourcetype/><d:getcontentlength>10</d:getcontentlength>` +
+		`<d:getlastmodified>Mon, 14 Apr 2025 10:00:00 GMT</d:getlastmodified><d:getetag>"x"</d:getetag></d:prop>` +
+		`<d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>` +
+		`<d:response><d:href>/claude-sync/sessions/a.enc</d:href><d:propstat><d:prop>` +
+		`<d:resourcetype/><d:getcontentlength>10</d:getcontentlength>` +
+		`<d:getlastmodified>Mon, 14 Apr 2025 10:00:00 GMT</d:getlastmodified><d:getetag>"y"</d:getetag></d:prop>` +
+		`<d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>` +
+		`</d:multistatus>`
+
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("Depth") != "infinity" {
+			t.Errorf("expected Depth: infinity, got %q", r.Header.Get("Depth"))
+		}
+		w.WriteHeader(207)
+		_, _ = w.Write([]byte(full))
+	}))
+	defer server.Close()
+
+	c, err := New(&storage.StorageConfig{
+		WebDAVURL:      server.URL,
+		PathPrefix:     prefix,
+		WebDAVUsername: "u",
+		WebDAVPassword: "p",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	objs, err := c.List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if requests != 1 {
+		t.Errorf("expected a single PROPFIND, got %d", requests)
+	}
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d: %+v", len(objs), objs)
 	}
 }


### PR DESCRIPTION
List() enumerated remote objects with a single Depth: infinity PROPFIND. Nextcloud and ownCloud allow this, but many WebDAV servers reject infinite-depth PROPFIND with 403/405/501 — notably Synology's WebDAV Server and Apache mod_dav (whose default is DavDepthInfinity off). On those servers push succeeds (PUT/MKCOL) but pull fails at the very first step with "failed to list objects: HTTP 403".

Fix: keep the Depth: infinity fast path, but when the server refuses it, fall back to a recursive Depth: 1 walk of the collection tree, which every WebDAV server supports. Factor the PROPFIND request, key extraction, and object collection into helpers shared by both paths.

Adds tests covering the 403 → Depth: 1 fallback (verifying every file in a nested tree is enumerated) and the single-request infinity fast path.

Fixes #52