### PR TITLE
fix(security): add download size limits to prevent memory exhaustion

### DIFF
--- a/cmd/claude-sync/backup_test.go
+++ b/cmd/claude-sync/backup_test.go
@@ -12,9 +12,7 @@ import (
 // world-readable either.
 func TestCreateBackupSetsRestrictivePermissions(t *testing.T) {
 	tmpHome := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpHome)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("HOME", tmpHome)
 
 	// Populate ~/.claude with a file inside a syncable subdirectory so that
 	// createBackup also creates a nested directory we can stat.

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -2063,6 +2063,10 @@ func verifyChecksum(release *GitHubRelease, assetName string, data []byte) error
 	return fmt.Errorf("checksums.txt has no entry for %s", assetName)
 }
 
+// maxBinarySize is the maximum allowed size for update binary downloads (200MB).
+// This prevents downloading excessively large files during update.
+const maxBinarySize = 200 * 1024 * 1024
+
 func downloadBinary(url string) ([]byte, error) {
 	client := &http.Client{Timeout: 5 * time.Minute}
 	resp, err := client.Get(url)
@@ -2075,7 +2079,17 @@ func downloadBinary(url string) ([]byte, error) {
 		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
 	}
 
-	return io.ReadAll(resp.Body)
+	// Limit download size to prevent downloading excessively large files
+	limited := io.LimitReader(resp.Body, maxBinarySize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBinarySize {
+		return nil, fmt.Errorf("binary exceeds maximum size of %d bytes", maxBinarySize)
+	}
+
+	return data, nil
 }
 
 func replaceBinary(execPath string, newBinary []byte) error {

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -2006,7 +2006,7 @@ func getLatestRelease() (*GitHubRelease, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
@@ -2073,7 +2073,7 @@ func downloadBinary(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
@@ -2102,7 +2102,7 @@ func replaceBinary(execPath string, newBinary []byte) error {
 	// Backup current binary
 	backupPath := execPath + ".old"
 	if err := os.Rename(execPath, backupPath); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to backup current binary: %w", err)
 	}
 
@@ -2114,7 +2114,7 @@ func replaceBinary(execPath string, newBinary []byte) error {
 	}
 
 	// Remove backup
-	os.Remove(backupPath)
+	_ = os.Remove(backupPath)
 
 	return nil
 }
@@ -2628,7 +2628,7 @@ func getAllReleases(limit int) ([]GitHubReleaseWithBody, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -543,7 +543,7 @@ func enterPassphraseAndVerify(ctx context.Context, store storage.Storage, keyPat
 
 			switch action {
 			case actionRetryPassphrase:
-				os.Remove(keyPath)
+				_ = os.Remove(keyPath)
 				fmt.Println()
 				printInfo("Enter a different passphrase:")
 				continue
@@ -552,7 +552,7 @@ func enterPassphraseAndVerify(ctx context.Context, store storage.Storage, keyPat
 				printInfo("Remote files will be cleared...")
 				return true, nil
 			case actionAbort:
-				os.Remove(keyPath)
+				_ = os.Remove(keyPath)
 				return false, fmt.Errorf("setup aborted")
 			}
 		}

--- a/cmd/claude-sync/reset_test.go
+++ b/cmd/claude-sync/reset_test.go
@@ -9,9 +9,7 @@ import (
 func TestResetClearsConfigDir(t *testing.T) {
 	// Create temp home directory
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("HOME", tmpDir)
 
 	// Create mock config directory
 	configDir := filepath.Join(tmpDir, ".claude-sync")
@@ -49,9 +47,7 @@ func TestResetClearsConfigDir(t *testing.T) {
 
 func TestResetClearsStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("HOME", tmpDir)
 
 	// Create config dir and state file
 	configDir := filepath.Join(tmpDir, ".claude-sync")
@@ -83,9 +79,7 @@ func TestResetClearsStateFile(t *testing.T) {
 
 func TestResetPreservesClaudeDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("HOME", tmpDir)
 
 	// Create both directories
 	configDir := filepath.Join(tmpDir, ".claude-sync")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -92,9 +92,7 @@ func TestClaudeDir(t *testing.T) {
 func TestSaveAndLoad(t *testing.T) {
 	// Create a temporary directory to use as home
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("HOME", tmpDir)
 
 	// Create config directory
 	configDir := filepath.Join(tmpDir, ConfigDir)
@@ -162,9 +160,7 @@ encryption_key_path: ~/.claude-sync/age-key.txt
 
 func TestLoadNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("HOME", tmpDir)
 
 	_, err := Load()
 	if err == nil {
@@ -178,9 +174,7 @@ func TestLoadNotFound(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", originalHome)
+	t.Setenv("HOME", tmpDir)
 
 	// Should not exist initially
 	if Exists() {

--- a/internal/storage/gcs/gcs.go
+++ b/internal/storage/gcs/gcs.go
@@ -12,8 +12,6 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
-	intstorage "github.com/tawanorg/claude-sync/internal/storage"
-
 	appstorage "github.com/tawanorg/claude-sync/internal/storage"
 )
 
@@ -84,13 +82,13 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	defer rc.Close()
 
 	// Limit download size to prevent memory exhaustion
-	limited := io.LimitReader(rc, intstorage.MaxDownloadSize+1)
+	limited := io.LimitReader(rc, appstorage.MaxDownloadSize+1)
 	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", key, err)
 	}
-	if int64(len(data)) > intstorage.MaxDownloadSize {
-		return nil, fmt.Errorf("file %s exceeds maximum download size of %d bytes", key, intstorage.MaxDownloadSize)
+	if int64(len(data)) > appstorage.MaxDownloadSize {
+		return nil, fmt.Errorf("file %s exceeds maximum download size of %d bytes", key, appstorage.MaxDownloadSize)
 	}
 
 	return data, nil

--- a/internal/storage/gcs/gcs.go
+++ b/internal/storage/gcs/gcs.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
+	intstorage "github.com/tawanorg/claude-sync/internal/storage"
+
 	appstorage "github.com/tawanorg/claude-sync/internal/storage"
 )
 
@@ -81,9 +83,14 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	}
 	defer rc.Close()
 
-	data, err := io.ReadAll(rc)
+	// Limit download size to prevent memory exhaustion
+	limited := io.LimitReader(rc, intstorage.MaxDownloadSize+1)
+	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", key, err)
+	}
+	if int64(len(data)) > intstorage.MaxDownloadSize {
+		return nil, fmt.Errorf("file %s exceeds maximum download size of %d bytes", key, intstorage.MaxDownloadSize)
 	}
 
 	return data, nil

--- a/internal/storage/gcs/gcs.go
+++ b/internal/storage/gcs/gcs.go
@@ -62,7 +62,7 @@ func (c *Client) Upload(ctx context.Context, key string, data []byte) error {
 	wc.ContentType = "application/octet-stream"
 
 	if _, err := wc.Write(data); err != nil {
-		wc.Close()
+		_ = wc.Close()
 		return fmt.Errorf("failed to write %s: %w", key, err)
 	}
 
@@ -79,7 +79,7 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s: %w", key, err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	// Limit download size to prevent memory exhaustion
 	limited := io.LimitReader(rc, appstorage.MaxDownloadSize+1)

--- a/internal/storage/r2/r2.go
+++ b/internal/storage/r2/r2.go
@@ -78,7 +78,7 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to download %s: %w", key, err)
 	}
-	defer result.Body.Close()
+	defer func() { _ = result.Body.Close() }()
 
 	// Limit download size to prevent memory exhaustion
 	limited := io.LimitReader(result.Body, storage.MaxDownloadSize+1)

--- a/internal/storage/r2/r2.go
+++ b/internal/storage/r2/r2.go
@@ -80,9 +80,14 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	}
 	defer result.Body.Close()
 
-	data, err := io.ReadAll(result.Body)
+	// Limit download size to prevent memory exhaustion
+	limited := io.LimitReader(result.Body, storage.MaxDownloadSize+1)
+	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", key, err)
+	}
+	if int64(len(data)) > storage.MaxDownloadSize {
+		return nil, fmt.Errorf("file %s exceeds maximum download size of %d bytes", key, storage.MaxDownloadSize)
 	}
 
 	return data, nil

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -88,7 +88,7 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to download %s: %w", key, err)
 	}
-	defer result.Body.Close()
+	defer func() { _ = result.Body.Close() }()
 
 	// Limit download size to prevent memory exhaustion
 	limited := io.LimitReader(result.Body, storage.MaxDownloadSize+1)

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -90,9 +90,14 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	}
 	defer result.Body.Close()
 
-	data, err := io.ReadAll(result.Body)
+	// Limit download size to prevent memory exhaustion
+	limited := io.LimitReader(result.Body, storage.MaxDownloadSize+1)
+	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", key, err)
+	}
+	if int64(len(data)) > storage.MaxDownloadSize {
+		return nil, fmt.Errorf("file %s exceeds maximum download size of %d bytes", key, storage.MaxDownloadSize)
 	}
 
 	return data, nil

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -16,6 +16,10 @@ const (
 	ProviderWebDAV Provider = "webdav"
 )
 
+// MaxDownloadSize is the maximum allowed size for a single downloaded object (100MB).
+// This prevents memory exhaustion from oversized or malicious remote files.
+const MaxDownloadSize = 100 * 1024 * 1024
+
 // ObjectInfo contains metadata about a stored object
 type ObjectInfo struct {
 	Key          string

--- a/internal/storage/webdav/integration_test.go
+++ b/internal/storage/webdav/integration_test.go
@@ -98,7 +98,8 @@ func (s *mockWebDAVServer) handlePropfind(w http.ResponseWriter, r *http.Request
 		responses = append(responses, s.buildPropfindEntry("/"+path+"/", 0, true, time.Now()))
 	}
 
-	if depth == "infinity" || depth == "1" {
+	switch depth {
+	case "infinity", "1":
 		prefix := path
 		if prefix != "" {
 			prefix += "/"
@@ -108,7 +109,7 @@ func (s *mockWebDAVServer) handlePropfind(w http.ResponseWriter, r *http.Request
 				responses = append(responses, s.buildPropfindEntry("/"+key, int64(len(f.data)), false, f.modTime))
 			}
 		}
-	} else if depth == "0" {
+	case "0":
 		f, ok := s.files[path]
 		if ok {
 			responses = append(responses, s.buildPropfindEntry("/"+path, int64(len(f.data)), f.isDir, f.modTime))

--- a/internal/storage/webdav/webdav.go
+++ b/internal/storage/webdav/webdav.go
@@ -130,9 +130,14 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to download %s: HTTP %d", key, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	// Limit download size to prevent memory exhaustion
+	limited := io.LimitReader(resp.Body, storage.MaxDownloadSize+1)
+	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", key, err)
+	}
+	if int64(len(data)) > storage.MaxDownloadSize {
+		return nil, fmt.Errorf("file %s exceeds maximum download size of %d bytes", key, storage.MaxDownloadSize)
 	}
 
 	return data, nil
@@ -169,6 +174,10 @@ func (c *Client) DeleteBatch(ctx context.Context, keys []string) error {
 }
 
 // propfindListBody is the PROPFIND request body used to enumerate objects.
+// maxPropfindResponseSize is the maximum allowed size for PROPFIND XML responses (10MB).
+// This prevents memory exhaustion from malicious servers sending huge XML payloads.
+const maxPropfindResponseSize = 10 * 1024 * 1024
+
 const propfindListBody = `<?xml version="1.0" encoding="UTF-8"?>
 <d:propfind xmlns:d="DAV:">
   <d:prop>
@@ -292,9 +301,14 @@ func (c *Client) propfind(ctx context.Context, url, depth string) ([]parsedRespo
 		return nil, resp.StatusCode, nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Limit response size to prevent memory exhaustion from large XML payloads
+	limited := io.LimitReader(resp.Body, maxPropfindResponseSize+1)
+	body, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("failed to read PROPFIND response: %w", err)
+	}
+	if int64(len(body)) > maxPropfindResponseSize {
+		return nil, resp.StatusCode, fmt.Errorf("PROPFIND response exceeds maximum size of %d bytes", maxPropfindResponseSize)
 	}
 
 	responses, err := parsePropfindResponse(body)
@@ -358,9 +372,14 @@ func (c *Client) Head(ctx context.Context, key string) (*storage.ObjectInfo, err
 		return nil, fmt.Errorf("failed to head %s: HTTP %d", key, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Limit response size to prevent memory exhaustion
+	limited := io.LimitReader(resp.Body, maxPropfindResponseSize+1)
+	body, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read PROPFIND response: %w", err)
+	}
+	if int64(len(body)) > maxPropfindResponseSize {
+		return nil, fmt.Errorf("PROPFIND response exceeds maximum size of %d bytes", maxPropfindResponseSize)
 	}
 
 	responses, err := parsePropfindResponse(body)

--- a/internal/storage/webdav/webdav.go
+++ b/internal/storage/webdav/webdav.go
@@ -105,7 +105,7 @@ func (c *Client) Upload(ctx context.Context, key string, data []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to upload %s: %w", key, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -121,7 +121,7 @@ func (c *Client) Download(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to download %s: %w", key, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("object not found: %s", key)
@@ -149,7 +149,7 @@ func (c *Client) Delete(ctx context.Context, key string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete %s: %w", key, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
 		return fmt.Errorf("failed to delete %s: HTTP %d", key, resp.StatusCode)
@@ -295,7 +295,7 @@ func (c *Client) propfind(ctx context.Context, url, depth string) ([]parsedRespo
 	if err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 207 {
 		return nil, resp.StatusCode, nil
@@ -362,7 +362,7 @@ func (c *Client) Head(ctx context.Context, key string) (*storage.ObjectInfo, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to head %s: %w", key, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("object not found: %s", key)
@@ -417,7 +417,7 @@ func (c *Client) BucketExists(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to check WebDAV path: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == 207 || resp.StatusCode == http.StatusOK {
 		return true, nil
@@ -432,7 +432,7 @@ func (c *Client) BucketExists(ctx context.Context) (bool, error) {
 		if mkErr != nil {
 			return false, fmt.Errorf("failed to create WebDAV directory '%s': %w", c.pathPrefix, mkErr)
 		}
-		mkResp.Body.Close()
+		_ = mkResp.Body.Close()
 		if mkResp.StatusCode == http.StatusCreated || mkResp.StatusCode == http.StatusMethodNotAllowed {
 			return true, nil
 		}
@@ -470,7 +470,7 @@ func (c *Client) ensureParentDirs(ctx context.Context, key string) error {
 		if err != nil {
 			return err
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		// 201 = created, 405 = already exists — both fine
 		if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusMethodNotAllowed && resp.StatusCode != http.StatusConflict {
 			if resp.StatusCode == http.StatusNotFound {

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -115,14 +115,14 @@ func (s *SyncState) Save() error {
 		return fmt.Errorf("failed to create temp state file: %w", err)
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath) // no-op if rename succeeded
+	defer func() { _ = os.Remove(tmpPath) }() // no-op if rename succeeded
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("failed to write state: %w", err)
 	}
 	if err := tmp.Chmod(0600); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("failed to set state permissions: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
@@ -206,7 +206,7 @@ func HashFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1099,7 +1099,7 @@ func gzipDecompress(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	// Limit decompressed size to prevent decompression bomb attacks
 	limited := io.LimitReader(r, maxDecompressedSize+1)

--- a/internal/sync/sync_push_pull_test.go
+++ b/internal/sync/sync_push_pull_test.go
@@ -263,7 +263,7 @@ func TestPushDeletesRemovedFiles(t *testing.T) {
 	}
 
 	// Delete local file
-	os.Remove(filepath.Join(env.claudeDir, "CLAUDE.md"))
+	_ = os.Remove(filepath.Join(env.claudeDir, "CLAUDE.md"))
 
 	// Push again
 	result, err := env.syncer.Push(ctx)


### PR DESCRIPTION
## Summary

- Add download size limits to all storage adapters (R2, S3, GCS, WebDAV) to prevent memory exhaustion attacks
- Add PROPFIND XML response size limit for WebDAV
- Add update binary download size limit

## Changes

| Location | Limit | Purpose |
|----------|-------|---------|
| `storage.MaxDownloadSize` | 100MB | Max file size for Download() methods |
| `webdav.maxPropfindResponseSize` | 10MB | Max WebDAV PROPFIND XML response |
| `main.maxBinarySize` | 200MB | Max update binary download |

## Security Impact

These limits prevent DoS attacks where a malicious or compromised remote server could cause memory exhaustion by serving oversized responses. Without these limits, `io.ReadAll` would consume unbounded memory.

## Test plan

- [x] All existing tests pass
- [x] Build succeeds for all packages
- [ ] Manual test: verify normal sync operations still work
- [ ] Manual test: verify error message when file exceeds limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)