### PR TITLE
feat: add rebuild-history command and pull --rebuild-history flag to fix /resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ claude-sync pull        # Download remote changes from cloud storage
 claude-sync status      # Show pending local changes
 claude-sync diff        # Show differences between local and remote
 claude-sync conflicts   # List and resolve conflicts
+claude-sync rebuild-history  # Rebuild ~/.claude/history.jsonl from session files
 claude-sync reset       # Reset configuration (forgot passphrase)
 claude-sync migrate     # Convert legacy remote keys to portable path-mapped keys
 claude-sync update      # Update to latest version (verifies release checksums)
@@ -251,10 +252,26 @@ claude-sync --help      # Show all commands
 ### Pull Options
 
 ```bash
-claude-sync pull              # Normal pull (prompts if existing files)
-claude-sync pull --dry-run    # Preview what would change
-claude-sync pull --force      # Skip confirmation prompts
+claude-sync pull                    # Normal pull (prompts if existing files)
+claude-sync pull --dry-run          # Preview what would change
+claude-sync pull --force            # Skip confirmation prompts
+claude-sync pull --rebuild-history  # Also rebuild history.jsonl after pulling
 ```
+
+### Rebuilding Prompt History
+
+`history.jsonl` is synced as a single file, so pushes from two devices are
+last-writer-wins and one device's prompt-history entries can be lost — which
+breaks the `/resume` session picker. Session files sync cleanly (one file per
+session), so the history can always be reconstructed from them:
+
+```bash
+claude-sync rebuild-history         # One-off rebuild
+claude-sync pull --rebuild-history  # Rebuild automatically after every pull
+```
+
+Existing entries are preserved, recovered entries are merged in and sorted by
+timestamp, and the previous file is kept as `history.jsonl.bak`.
 
 ### Init Options
 

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -67,6 +67,7 @@ func main() {
 		statusCmd(),
 		diffCmd(),
 		conflictsCmd(),
+		rebuildHistoryCmd(),
 		resetCmd(),
 		migrateCmd(),
 		updateCmd(),
@@ -1104,7 +1105,7 @@ func pushCmd() *cobra.Command {
 }
 
 func pullCmd() *cobra.Command {
-	var dryRun, force, includeMCP bool
+	var dryRun, force, includeMCP, rebuildHistory bool
 
 	cmd := &cobra.Command{
 		Use:   "pull",
@@ -1115,9 +1116,10 @@ On first pull with existing local files, you'll be prompted to confirm
 before any files are overwritten. Use --dry-run to preview changes first.
 
 Examples:
-  claude-sync pull              # Pull with safety prompts
-  claude-sync pull --dry-run    # Preview what would be changed
-  claude-sync pull --force      # Skip confirmation prompts`,
+  claude-sync pull                    # Pull with safety prompts
+  claude-sync pull --dry-run          # Preview what would be changed
+  claude-sync pull --force            # Skip confirmation prompts
+  claude-sync pull --rebuild-history  # Also rebuild history.jsonl from session files`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
@@ -1233,6 +1235,12 @@ Examples:
 				}
 			}
 
+			if rebuildHistory {
+				if err := runHistoryRebuild(); err != nil {
+					return fmt.Errorf("rebuilding history: %w", err)
+				}
+			}
+
 			return nil
 		},
 	}
@@ -1240,8 +1248,42 @@ Examples:
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be changed without making changes")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing files without confirmation")
 	cmd.Flags().BoolVar(&includeMCP, "include-mcp", false, "Also sync MCP server configs from ~/.claude.json")
+	cmd.Flags().BoolVar(&rebuildHistory, "rebuild-history", false, "Rebuild ~/.claude/history.jsonl from session files after pulling")
 
 	return cmd
+}
+
+func rebuildHistoryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rebuild-history",
+		Short: "Rebuild ~/.claude/history.jsonl from session files",
+		Long: `Reconstruct the prompt history by merging the current history.jsonl with
+user prompts extracted from session files under ~/.claude/projects/.
+
+history.jsonl is synced as a single file, so pushes from two devices are
+last-writer-wins and one device's entries can be lost, breaking the /resume
+session picker. Session files sync cleanly (one file per session), so the
+full history can always be rebuilt from them.
+
+Existing history entries are preserved as-is; recovered entries are merged
+in, deduplicated, and sorted by timestamp. The previous file is kept as
+history.jsonl.bak.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHistoryRebuild()
+		},
+	}
+}
+
+func runHistoryRebuild() error {
+	result, err := sync.RebuildHistory(config.ClaudeDir())
+	if err != nil {
+		return err
+	}
+	if !quiet {
+		fmt.Printf("%s✓%s History rebuilt: %d existing + %d recovered from sessions → %d entries\n",
+			colorGreen, colorReset, result.Existing, result.Reconstructed, result.Merged)
+	}
+	return nil
 }
 
 func statusCmd() *cobra.Command {

--- a/internal/sync/history.go
+++ b/internal/sync/history.go
@@ -1,0 +1,349 @@
+package sync
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HistoryFile is the prompt-history file inside the Claude directory.
+const HistoryFile = "history.jsonl"
+
+// history.jsonl is synced as a single opaque file, so concurrent pushes from
+// two devices are last-writer-wins and one device's entries get lost. Session
+// files under projects/ sync cleanly (one uniquely-named file per session),
+// so the prompt history can always be reconstructed from them.
+
+// HistoryEntry mirrors one line of ~/.claude/history.jsonl.
+type HistoryEntry struct {
+	Display        string          `json:"display"`
+	PastedContents json.RawMessage `json:"pastedContents"`
+	Timestamp      int64           `json:"timestamp"`
+	Project        string          `json:"project"`
+	SessionID      string          `json:"sessionId"`
+}
+
+// RebuildHistoryResult reports what RebuildHistory did.
+type RebuildHistoryResult struct {
+	Existing      int // valid entries already in history.jsonl
+	Reconstructed int // entries recovered from session files
+	Merged        int // entries written after dedup
+}
+
+var (
+	commandNameRe = regexp.MustCompile(`(?s)<command-name>(.*?)</command-name>`)
+	commandArgsRe = regexp.MustCompile(`(?s)<command-args>(.*?)</command-args>`)
+)
+
+// sessionLine is the subset of a session-file line needed for reconstruction.
+type sessionLine struct {
+	Type        string `json:"type"`
+	SessionID   string `json:"sessionId"`
+	Timestamp   string `json:"timestamp"`
+	Cwd         string `json:"cwd"`
+	IsMeta      bool   `json:"isMeta"`
+	IsSidechain bool   `json:"isSidechain"`
+	Message     struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// mergedEntry keeps the original raw line for existing entries so unknown
+// fields (e.g. pastedContents payloads) survive the rewrite.
+type mergedEntry struct {
+	raw       []byte
+	timestamp int64
+}
+
+// RebuildHistory reconstructs history.jsonl by merging its current entries
+// with user prompts extracted from session files under projects/. Existing
+// entries win on conflict (they preserve exact text and pasted contents).
+// The previous file is kept as history.jsonl.bak and the new file is written
+// atomically.
+func RebuildHistory(claudeDir string) (*RebuildHistoryResult, error) {
+	historyPath := filepath.Join(claudeDir, HistoryFile)
+	result := &RebuildHistoryResult{}
+	merged := make(map[string]mergedEntry)
+
+	reconstructed, err := reconstructHistoryEntries(filepath.Join(claudeDir, "projects"))
+	if err != nil {
+		return nil, err
+	}
+	result.Reconstructed = len(reconstructed)
+	for _, e := range reconstructed {
+		key := historyDedupeKey(e.SessionID, e.Display, e.Timestamp)
+		if _, ok := merged[key]; !ok {
+			raw, err := json.Marshal(e)
+			if err != nil {
+				return nil, fmt.Errorf("marshalling history entry: %w", err)
+			}
+			merged[key] = mergedEntry{raw: raw, timestamp: e.Timestamp}
+		}
+	}
+
+	existing, err := loadHistoryLines(historyPath)
+	if err != nil {
+		return nil, err
+	}
+	result.Existing = len(existing)
+	for _, e := range existing {
+		key := historyDedupeKey(e.entry.SessionID, e.entry.Display, e.entry.Timestamp)
+		merged[key] = mergedEntry{raw: e.raw, timestamp: e.entry.Timestamp}
+	}
+
+	entries := make([]mergedEntry, 0, len(merged))
+	for _, e := range merged {
+		entries = append(entries, e)
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].timestamp < entries[j].timestamp
+	})
+	result.Merged = len(entries)
+
+	if err := writeHistoryFile(historyPath, entries); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// historyDedupeKey treats the same prompt in the same session within a
+// 2-minute bucket as one entry: reconstructed timestamps come from session
+// files and can differ slightly from the original submit time.
+func historyDedupeKey(sessionID, display string, timestamp int64) string {
+	return fmt.Sprintf("%s\x00%s\x00%d", sessionID, display, timestamp/120000)
+}
+
+type existingLine struct {
+	raw   []byte
+	entry HistoryEntry
+}
+
+func loadHistoryLines(historyPath string) ([]existingLine, error) {
+	f, err := os.Open(historyPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open %s: %w", historyPath, err)
+	}
+	defer f.Close()
+
+	var lines []existingLine
+	err = forEachLine(f, func(line []byte) {
+		var entry HistoryEntry
+		if json.Unmarshal(line, &entry) != nil {
+			return
+		}
+		if entry.Display == "" || entry.Timestamp == 0 {
+			return
+		}
+		raw := make([]byte, len(line))
+		copy(raw, line)
+		lines = append(lines, existingLine{raw: raw, entry: entry})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", historyPath, err)
+	}
+	return lines, nil
+}
+
+func reconstructHistoryEntries(projectsDir string) ([]HistoryEntry, error) {
+	projects, err := os.ReadDir(projectsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", projectsDir, err)
+	}
+
+	var entries []HistoryEntry
+	for _, project := range projects {
+		if !project.IsDir() {
+			continue
+		}
+		projectDir := filepath.Join(projectsDir, project.Name())
+		sessions, err := os.ReadDir(projectDir)
+		if err != nil {
+			continue
+		}
+		for _, session := range sessions {
+			if session.IsDir() || !strings.HasSuffix(session.Name(), ".jsonl") {
+				continue
+			}
+			sessionPath := filepath.Join(projectDir, session.Name())
+			fileEntries, err := entriesFromSessionFile(sessionPath)
+			if err != nil {
+				continue // an unreadable session file shouldn't abort the rebuild
+			}
+			entries = append(entries, fileEntries...)
+		}
+	}
+	return entries, nil
+}
+
+func entriesFromSessionFile(path string) ([]HistoryEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fallbackSessionID := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+
+	var entries []HistoryEntry
+	err = forEachLine(f, func(line []byte) {
+		var sl sessionLine
+		if json.Unmarshal(line, &sl) != nil {
+			return
+		}
+		if sl.Type != "user" || sl.IsMeta || sl.IsSidechain {
+			return
+		}
+		display, ok := displayFromContent(sl.Message.Content)
+		if !ok {
+			return
+		}
+		ts, err := time.Parse(time.RFC3339Nano, sl.Timestamp)
+		if err != nil {
+			return
+		}
+		sessionID := sl.SessionID
+		if sessionID == "" {
+			sessionID = fallbackSessionID
+		}
+		entries = append(entries, HistoryEntry{
+			Display:        display,
+			PastedContents: json.RawMessage("{}"),
+			Timestamp:      ts.UnixMilli(),
+			Project:        sl.Cwd,
+			SessionID:      sessionID,
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// displayFromContent extracts what the user typed from a user message's
+// content, which is either a plain string or a list of content blocks.
+// Returns false for tool results and harness-injected content.
+func displayFromContent(content json.RawMessage) (string, bool) {
+	var text string
+	var asString string
+	if err := json.Unmarshal(content, &asString); err == nil {
+		text = asString
+	} else {
+		var blocks []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(content, &blocks); err != nil {
+			return "", false
+		}
+		var parts []string
+		for _, b := range blocks {
+			if b.Type == "tool_result" {
+				return "", false
+			}
+			if b.Type == "text" && b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		}
+		text = strings.Join(parts, "\n")
+	}
+
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", false
+	}
+	for _, prefix := range []string{"<local-command-stdout>", "<system-reminder>", "Caveat:"} {
+		if strings.HasPrefix(text, prefix) {
+			return "", false
+		}
+	}
+	// Slash commands are stored as <command-name>/foo</command-name><command-args>...
+	if m := commandNameRe.FindStringSubmatch(text); m != nil {
+		cmd := strings.TrimSpace(m[1])
+		if cmd == "" {
+			return "", false
+		}
+		if args := commandArgsRe.FindStringSubmatch(text); args != nil {
+			if a := strings.TrimSpace(args[1]); a != "" {
+				return cmd + " " + a, true
+			}
+		}
+		return cmd, true
+	}
+	if strings.HasPrefix(text, "<") {
+		return "", false
+	}
+	return text, true
+}
+
+func writeHistoryFile(historyPath string, entries []mergedEntry) error {
+	dir := filepath.Dir(historyPath)
+
+	if data, err := os.ReadFile(historyPath); err == nil {
+		if err := os.WriteFile(historyPath+".bak", data, 0600); err != nil {
+			return fmt.Errorf("failed to back up %s: %w", historyPath, err)
+		}
+	}
+
+	tmp, err := os.CreateTemp(dir, ".history-*.jsonl")
+	if err != nil {
+		return fmt.Errorf("creating temp history file: %w", err)
+	}
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name()) // no-op after successful rename
+	}()
+
+	w := bufio.NewWriter(tmp)
+	for _, e := range entries {
+		if _, err := w.Write(e.raw); err != nil {
+			return err
+		}
+		if err := w.WriteByte('\n'); err != nil {
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp.Name(), historyPath); err != nil {
+		return fmt.Errorf("replacing %s: %w", historyPath, err)
+	}
+	return nil
+}
+
+// forEachLine calls fn for every non-empty line. It reads unbounded line
+// lengths (session-file lines with tool results can be many MB).
+func forEachLine(r io.Reader, fn func(line []byte)) error {
+	reader := bufio.NewReaderSize(r, 64*1024)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if trimmed := strings.TrimSpace(string(line)); trimmed != "" {
+			fn([]byte(trimmed))
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/internal/sync/history_test.go
+++ b/internal/sync/history_test.go
@@ -1,0 +1,204 @@
+package sync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeHistoryFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readHistory(t *testing.T, claudeDir string) []HistoryEntry {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(claudeDir, HistoryFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []HistoryEntry
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e HistoryEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("invalid history line %q: %v", line, err)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+const sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+func sessionFixture() string {
+	lines := []string{
+		// Plain user prompt — should be recovered.
+		`{"type":"user","sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:00:00.500Z","cwd":"/home/u/proj","message":{"role":"user","content":"fix the login bug"}}`,
+		// Tool result — must be skipped.
+		`{"type":"user","sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:00:05Z","cwd":"/home/u/proj","message":{"role":"user","content":[{"tool_use_id":"t1","type":"tool_result","content":"ok"}]}}`,
+		// Assistant line — skipped.
+		`{"type":"assistant","sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:00:06Z","cwd":"/home/u/proj","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`,
+		// Meta and sidechain lines — skipped.
+		`{"type":"user","isMeta":true,"sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:00:07Z","cwd":"/home/u/proj","message":{"role":"user","content":"meta"}}`,
+		`{"type":"user","isSidechain":true,"sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:00:08Z","cwd":"/home/u/proj","message":{"role":"user","content":"sidechain"}}`,
+		// Slash command — display reconstructed as "/context extra".
+		`{"type":"user","sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:01:00Z","cwd":"/home/u/proj","message":{"role":"user","content":"<command-name>/context</command-name><command-args>extra</command-args>"}}`,
+		// Harness-injected content — skipped.
+		`{"type":"user","sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:02:00Z","cwd":"/home/u/proj","message":{"role":"user","content":"<local-command-stdout>out</local-command-stdout>"}}`,
+		`{"type":"user","sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:02:01Z","cwd":"/home/u/proj","message":{"role":"user","content":"Caveat: injected"}}`,
+		// Content-block form — recovered.
+		`{"type":"user","sessionId":"` + sessionID + `","timestamp":"2026-01-02T10:03:00Z","cwd":"/home/u/proj","message":{"role":"user","content":[{"type":"text","text":"second prompt"}]}}`,
+		// Malformed line — ignored without aborting.
+		`{not json`,
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func TestRebuildHistoryFromSessions(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeHistoryFixture(t, filepath.Join(claudeDir, "projects", "-home-u-proj", sessionID+".jsonl"), sessionFixture())
+
+	result, err := RebuildHistory(claudeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Existing != 0 || result.Reconstructed != 3 || result.Merged != 3 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	entries := readHistory(t, claudeDir)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(entries), entries)
+	}
+	wantDisplays := []string{"fix the login bug", "/context extra", "second prompt"}
+	for i, want := range wantDisplays {
+		if entries[i].Display != want {
+			t.Errorf("entry %d display = %q, want %q", i, entries[i].Display, want)
+		}
+		if entries[i].SessionID != sessionID {
+			t.Errorf("entry %d sessionId = %q", i, entries[i].SessionID)
+		}
+		if entries[i].Project != "/home/u/proj" {
+			t.Errorf("entry %d project = %q", i, entries[i].Project)
+		}
+	}
+	if entries[0].Timestamp != 1767348000500 {
+		t.Errorf("timestamp = %d, want 1767348000500", entries[0].Timestamp)
+	}
+}
+
+func TestRebuildHistoryMergesWithExisting(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeHistoryFixture(t, filepath.Join(claudeDir, "projects", "-home-u-proj", sessionID+".jsonl"), sessionFixture())
+
+	// Existing history: one entry that overlaps the session file (submitted a
+	// few hundred ms before the session-file timestamp, with pastedContents
+	// that must survive), one unique entry, and one junk line.
+	existing := strings.Join([]string{
+		`{"display":"fix the login bug","pastedContents":{"1":{"content":"paste"}},"timestamp":1767348000100,"project":"/home/u/proj","sessionId":"` + sessionID + `"}`,
+		`{"display":"only in history","pastedContents":{},"timestamp":1767348100000,"project":"/home/u/other","sessionId":"other-session"}`,
+		`garbage line`,
+	}, "\n") + "\n"
+	writeHistoryFixture(t, filepath.Join(claudeDir, HistoryFile), existing)
+
+	result, err := RebuildHistory(claudeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Existing != 2 {
+		t.Errorf("Existing = %d, want 2", result.Existing)
+	}
+	// 3 reconstructed, but "fix the login bug" dedupes against the existing
+	// entry (same session, same display, same 2-minute bucket).
+	if result.Merged != 4 {
+		t.Fatalf("Merged = %d, want 4 (result: %+v)", result.Merged, result)
+	}
+
+	entries := readHistory(t, claudeDir)
+	byDisplay := map[string]HistoryEntry{}
+	for _, e := range entries {
+		byDisplay[e.Display] = e
+	}
+	// The existing entry wins: original timestamp and pastedContents kept.
+	kept := byDisplay["fix the login bug"]
+	if kept.Timestamp != 1767348000100 {
+		t.Errorf("deduped entry timestamp = %d, want existing 1767348000100", kept.Timestamp)
+	}
+	if !strings.Contains(string(kept.PastedContents), "paste") {
+		t.Errorf("pastedContents lost: %s", kept.PastedContents)
+	}
+	if _, ok := byDisplay["only in history"]; !ok {
+		t.Error("entry unique to history.jsonl was dropped")
+	}
+
+	// Sorted by timestamp.
+	for i := 1; i < len(entries); i++ {
+		if entries[i].Timestamp < entries[i-1].Timestamp {
+			t.Errorf("entries not sorted at index %d", i)
+		}
+	}
+
+	// Backup of the previous file exists.
+	bak, err := os.ReadFile(filepath.Join(claudeDir, HistoryFile+".bak"))
+	if err != nil {
+		t.Fatalf("backup not written: %v", err)
+	}
+	if string(bak) != existing {
+		t.Error("backup does not match previous history content")
+	}
+}
+
+func TestRebuildHistoryNoSourcesIsEmpty(t *testing.T) {
+	claudeDir := t.TempDir()
+	result, err := RebuildHistory(claudeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Existing != 0 || result.Reconstructed != 0 || result.Merged != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	data, err := os.ReadFile(filepath.Join(claudeDir, HistoryFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty history file, got %q", data)
+	}
+}
+
+func TestDisplayFromContent(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+		ok      bool
+	}{
+		{"plain string", `"hello world"`, "hello world", true},
+		{"whitespace only", `"   "`, "", false},
+		{"tool result", `[{"type":"tool_result","content":"x"}]`, "", false},
+		{"text blocks", `[{"type":"text","text":"a"},{"type":"text","text":"b"}]`, "a\nb", true},
+		{"command no args", `"<command-name>/clear</command-name><command-args></command-args>"`, "/clear", true},
+		{"command with args", `"<command-name>/model</command-name><command-args>opus</command-args>"`, "/model opus", true},
+		{"system reminder", `"<system-reminder>x</system-reminder>"`, "", false},
+		{"unknown xml", `"<something>x</something>"`, "", false},
+		{"invalid json", `12345`, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := displayFromContent(json.RawMessage(tc.content))
+			if ok != tc.ok || got != tc.want {
+				t.Errorf("displayFromContent(%s) = (%q, %v), want (%q, %v)", tc.content, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
TLDR: It fixes the issue that /resume not showing pulled sessions.

history.jsonl is synced as a single opaque file, so pushes from two devices are last-writer-wins and one device's prompt-history entries get lost, breaking the /resume session picker. Session files under projects/ sync cleanly (one uniquely-named file per session), so the prompt history can always be reconstructed from them.

RebuildHistory merges the current history.jsonl with user prompts extracted from session files (skipping tool results, sidechains, and harness-injected content; slash commands are restored to their /name args form), dedupes per session/display/2-minute bucket with existing entries winning, sorts by timestamp, backs up the previous file to history.jsonl.bak, and writes atomically.