### PR TITLE
feat(storage): add path-style addressing for S3-compatible endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ claude-sync init --provider s3-compatible --endpoint https://s3.us-west-004.back
 
 You'll need: Endpoint URL, Access Key ID, Secret Access Key, Bucket. The signing region is auto-detected from the endpoint (e.g. `us-west-004`); for providers that ignore it, `auto` is used.
 
+For servers that don't resolve buckets as subdomains (e.g. Ceph RGW, or MinIO without wildcard DNS), add `--use-path-style` to address objects as `endpoint/bucket/key` instead of `bucket.endpoint/key`:
+
+```bash
+claude-sync init --provider s3-compatible --endpoint https://ceph.example.com --use-path-style
+```
+
+It's off by default and unnecessary for Backblaze B2, Wasabi, and DigitalOcean Spaces, which all support virtual-hosted addressing.
+
 > Custom endpoints automatically relax the AWS SDK's default integrity-checksum headers, which some S3-compatible providers reject. AWS S3 behavior is unchanged.
 </details>
 

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -130,6 +130,7 @@ func initCmd() *cobra.Command {
 
 	// S3-compatible (custom endpoint) flags
 	var s3Endpoint string
+	var s3UsePathStyle bool
 
 	// GCS flags
 	var gcsProjectID, gcsCredentialsFile string
@@ -167,7 +168,7 @@ Examples:
 			}
 
 			// Normal flow: full setup
-			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, s3Endpoint, gcsProjectID, gcsCredentialsFile, webdavURL, webdavUsername, webdavPassword, webdavPathPrefix, scope, usePassphrase, force)
+			return initFullSetup(ctx, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, s3Endpoint, s3UsePathStyle, gcsProjectID, gcsCredentialsFile, webdavURL, webdavUsername, webdavPassword, webdavPathPrefix, scope, usePassphrase, force)
 		},
 	}
 
@@ -188,6 +189,7 @@ Examples:
 
 	// S3-compatible flags
 	cmd.Flags().StringVar(&s3Endpoint, "endpoint", "", "Custom S3-compatible endpoint URL (e.g. https://s3.us-west-004.backblazeb2.com)")
+	cmd.Flags().BoolVar(&s3UsePathStyle, "use-path-style", false, "Use path-style URLs (endpoint/bucket/key) for S3-compatible endpoints that don't resolve buckets as subdomains (e.g. Ceph, MinIO)")
 
 	// GCS flags
 	cmd.Flags().StringVar(&gcsProjectID, "project-id", "", "GCP Project ID (GCS)")
@@ -272,7 +274,7 @@ func resolveScope(scope string) (string, error) {
 }
 
 // initFullSetup handles the full init wizard
-func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, s3Endpoint, gcsProjectID, gcsCredentialsFile, webdavURL, webdavUsername, webdavPassword, webdavPathPrefix, scope string, usePassphrase, force bool) error {
+func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, accessKey, secretKey, s3Region, s3Endpoint string, s3UsePathStyle bool, gcsProjectID, gcsCredentialsFile, webdavURL, webdavUsername, webdavPassword, webdavPathPrefix, scope string, usePassphrase, force bool) error {
 	if config.Exists() && !force {
 		var overwrite bool
 		prompt := &survey.Confirm{
@@ -331,7 +333,7 @@ func initFullSetup(ctx context.Context, keyPath, provider, bucket, accountID, ac
 	case "gcs":
 		storageCfg, err = runGCSWizard(gcsProjectID, gcsCredentialsFile, bucket)
 	case "s3-compatible":
-		storageCfg, err = runS3CompatibleWizard(s3Endpoint, accessKey, secretKey, s3Region, bucket)
+		storageCfg, err = runS3CompatibleWizard(s3Endpoint, accessKey, secretKey, s3Region, bucket, s3UsePathStyle)
 	case "webdav":
 		storageCfg, err = runWebDAVWizard(webdavURL, webdavUsername, webdavPassword, webdavPathPrefix)
 	default:
@@ -734,7 +736,7 @@ func runS3Wizard(accessKey, secretKey, region, bucket string) (*storage.StorageC
 // It reuses the S3 storage engine (ProviderS3 with Endpoint set); the engine
 // relaxes checksum behavior for custom endpoints so these providers accept the
 // uploads. The signing region is pre-filled from the endpoint when derivable.
-func runS3CompatibleWizard(endpoint, accessKey, secretKey, region, bucket string) (*storage.StorageConfig, error) {
+func runS3CompatibleWizard(endpoint, accessKey, secretKey, region, bucket string, usePathStyle bool) (*storage.StorageConfig, error) {
 	fmt.Printf("  %sS3-Compatible Setup%s\n\n", colorBold, colorReset)
 	printInfo("Works with any S3-compatible provider: Backblaze B2, MinIO, Wasabi, DigitalOcean Spaces, ...")
 	fmt.Println()
@@ -757,15 +759,17 @@ func runS3CompatibleWizard(endpoint, accessKey, secretKey, region, bucket string
 	}
 
 	answers := struct {
-		AccessKey string
-		SecretKey string
-		Region    string
-		Bucket    string
+		AccessKey    string
+		SecretKey    string
+		Region       string
+		Bucket       string
+		UsePathStyle bool
 	}{
-		AccessKey: accessKey,
-		SecretKey: secretKey,
-		Region:    region,
-		Bucket:    bucket,
+		AccessKey:    accessKey,
+		SecretKey:    secretKey,
+		Region:       region,
+		Bucket:       bucket,
+		UsePathStyle: usePathStyle,
 	}
 
 	questions := []*survey.Question{
@@ -801,6 +805,14 @@ func runS3CompatibleWizard(endpoint, accessKey, secretKey, region, bucket string
 			},
 			Validate: survey.Required,
 		},
+		{
+			Name: "UsePathStyle",
+			Prompt: &survey.Confirm{
+				Message: "Use path-style URLs (endpoint/bucket/key)?",
+				Default: usePathStyle,
+				Help:    "Enable for servers that don't resolve buckets as subdomains, e.g. Ceph RGW or MinIO without wildcard DNS. Leave off for Backblaze B2, Wasabi, DigitalOcean Spaces.",
+			},
+		},
 	}
 
 	if err := survey.Ask(questions, &answers); err != nil {
@@ -814,6 +826,7 @@ func runS3CompatibleWizard(endpoint, accessKey, secretKey, region, bucket string
 		SecretAccessKey: answers.SecretKey,
 		Region:          answers.Region,
 		Endpoint:        storage.NormalizeEndpoint(endpoint),
+		UsePathStyle:    answers.UsePathStyle,
 	}, nil
 }
 

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -62,6 +62,12 @@ type StorageConfig struct {
 	Endpoint        string `yaml:"endpoint,omitempty"`
 	Region          string `yaml:"region,omitempty"`
 
+	// UsePathStyle forces path-style addressing (endpoint/bucket/key) instead of
+	// virtual-hosted style (bucket.endpoint/key). Required by S3-compatible
+	// servers that don't resolve buckets as subdomains (e.g. Ceph RGW, MinIO
+	// without wildcard DNS). Only honored when a custom Endpoint is set.
+	UsePathStyle bool `yaml:"use_path_style,omitempty"`
+
 	// R2-specific
 	AccountID string `yaml:"account_id,omitempty"`
 

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -61,6 +61,10 @@ func buildS3Options(cfg *storage.StorageConfig) func(*s3.Options) {
 			o.BaseEndpoint = aws.String(storage.NormalizeEndpoint(cfg.Endpoint))
 			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 			o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
+			// Path-style addressing for servers that don't resolve buckets as
+			// subdomains (Ceph RGW, MinIO without wildcard DNS). Left false for
+			// AWS, which prefers virtual-hosted style.
+			o.UsePathStyle = cfg.UsePathStyle
 		}
 	}
 }

--- a/internal/storage/s3/s3_test.go
+++ b/internal/storage/s3/s3_test.go
@@ -28,6 +28,36 @@ func TestBuildS3Options_CustomEndpoint(t *testing.T) {
 	}
 }
 
+func TestBuildS3Options_UsePathStyleWithCustomEndpoint(t *testing.T) {
+	cfg := &storage.StorageConfig{
+		Endpoint:     "https://ceph.internal.example.com",
+		UsePathStyle: true,
+	}
+
+	opts := &awss3.Options{}
+	buildS3Options(cfg)(opts)
+
+	if !opts.UsePathStyle {
+		t.Error("UsePathStyle = false, want true for custom endpoint with UsePathStyle set")
+	}
+}
+
+func TestBuildS3Options_UsePathStyleIgnoredWithoutEndpoint(t *testing.T) {
+	// UsePathStyle only applies to custom endpoints; on AWS-native (no endpoint)
+	// it must be ignored so virtual-hosted addressing is preserved.
+	cfg := &storage.StorageConfig{
+		Region:       "us-east-1",
+		UsePathStyle: true,
+	}
+
+	opts := &awss3.Options{}
+	buildS3Options(cfg)(opts)
+
+	if opts.UsePathStyle {
+		t.Error("UsePathStyle = true, want false when no custom endpoint is configured")
+	}
+}
+
 func TestBuildS3Options_EndpointWithoutSchemeNormalized(t *testing.T) {
 	cfg := &storage.StorageConfig{
 		Endpoint: "s3.eu-central-003.backblazeb2.com", // no scheme


### PR DESCRIPTION
## Summary
- Add a `--use-path-style` init flag and a `use_path_style` config option that switch S3-compatible clients to path-style addressing (`endpoint/bucket/key`) instead of virtual-hosted style (`bucket.endpoint/key`).
- Enables providers that don't resolve buckets as subdomains — e.g. Ceph RGW, or MinIO without wildcard DNS — which otherwise fail on virtual-hosted requests.
- The option is honored **only when a custom endpoint is set**, so AWS-native S3 addressing is unchanged.
- Wired end-to-end: CLI flag → init wizard prompt → `StorageConfig` → S3 client option.
- Documented in the README S3-compatible section.

## Testing
- Two new unit tests in `internal/storage/s3`: path-style applied for a custom endpoint, and ignored when no endpoint is configured (guards the AWS-native path).
- `go build ./...`, `go vet`, and `go test ./...` all pass locally.

## Notes
- Reference: reworked from the idea in #59, reimplemented independently rather than merged.
- No dependency changes; no impact on R2/GCS/WebDAV backends.