### PR TITLE
style: fix gofmt formatting + add CI gofmt gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt-formatted. Run 'make fmt':"
+            echo "$unformatted"
+            exit 1
+          fi
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:

--- a/internal/claudesettings/settings_test.go
+++ b/internal/claudesettings/settings_test.go
@@ -12,10 +12,10 @@ import (
 
 // MockRepository implements SettingsRepository for testing.
 type MockRepository struct {
-	data      map[string][]byte
-	readErr   error
-	writeErr  error
-	mkdirErr  error
+	data       map[string][]byte
+	readErr    error
+	writeErr   error
+	mkdirErr   error
 	writeCalls []writeCall
 }
 

--- a/internal/crypto/encrypt_test.go
+++ b/internal/crypto/encrypt_test.go
@@ -330,10 +330,10 @@ func TestValidatePassphraseStrength(t *testing.T) {
 		passphrase string
 		wantErr    bool
 	}{
-		{"short", true},        // Too short (< 12)
-		{"1234567", true},      // Still too short (7 chars)
-		{"12345678", true},     // Still too short (8 chars, now requires 12)
-		{"12345678901", true},  // Still too short (11 chars)
+		{"short", true},         // Too short (< 12)
+		{"1234567", true},       // Still too short (7 chars)
+		{"12345678", true},      // Still too short (8 chars, now requires 12)
+		{"12345678901", true},   // Still too short (11 chars)
 		{"123456789012", false}, // Minimum length (12)
 		{"longenoughpass", false},
 		{"very-long-passphrase-that-is-secure", false},

--- a/internal/paths/manager.go
+++ b/internal/paths/manager.go
@@ -276,11 +276,11 @@ func (m *Manager) HasExclude(pattern string) bool {
 
 // Status returns information about the current sync configuration.
 type Status struct {
-	SyncPaths     []string
-	Excludes      []string
-	CustomPaths   []string // Non-default paths
+	SyncPaths       []string
+	Excludes        []string
+	CustomPaths     []string // Non-default paths
 	RemovedDefaults []string // Defaults that were removed (in excludes)
-	IsCustomized  bool
+	IsCustomized    bool
 }
 
 // Status returns the current sync configuration status.


### PR DESCRIPTION
## Summary
- Apply `gofmt` to three files that were committed unformatted (`internal/paths/manager.go`, `internal/crypto/encrypt_test.go`, `internal/claudesettings/settings_test.go`). They were flagged as unformatted under **both** Go 1.24 and Go 1.25; the reformatted result is stable across both. No behavior change.
- Add a `gofmt -l` gate to the CI `lint` job so unformatted code can't land again — CI previously had no formatting check (golangci-lint's default linters exclude `gofmt`), which is how these slipped in.

## Why
`make check` / whole-repo `gofmt -l .` was failing locally on files unrelated to any feature. Root cause: the files were genuinely misformatted and nothing in CI enforced formatting.

## Testing
- `gofmt -l .` clean under both Go 1.24 and Go 1.25
- `go build ./...` and `go test ./...` pass
- CI YAML validated