### PR TITLE
feat: apply sync_paths override with scope as a hard ceiling

### DIFF
--- a/cmd/claude-sync/backup_test.go
+++ b/cmd/claude-sync/backup_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tawanorg/claude-sync/internal/config"
 )
 
 // TestCreateBackupSetsRestrictivePermissions verifies that the backup directory
@@ -26,7 +28,7 @@ func TestCreateBackupSetsRestrictivePermissions(t *testing.T) {
 		t.Fatalf("Failed to create helper.json: %v", err)
 	}
 
-	backupDir, err := createBackup("")
+	backupDir, err := createBackup(config.SyncPaths)
 	if err != nil {
 		t.Fatalf("createBackup failed: %v", err)
 	}

--- a/cmd/claude-sync/main.go
+++ b/cmd/claude-sync/main.go
@@ -1147,7 +1147,7 @@ Examples:
 
 			// Check for first pull with existing local files
 			if !syncer.HasState() {
-				hasExisting, err := hasExistingClaudeFiles(cfg.Scope)
+				hasExisting, err := hasExistingClaudeFiles(cfg)
 				if err != nil {
 					return err
 				}
@@ -2287,13 +2287,13 @@ func clearRemoteStorage(ctx context.Context, store storage.Storage) error {
 }
 
 // hasExistingClaudeFiles checks if ~/.claude has any files that would be synced
-func hasExistingClaudeFiles(scope string) (bool, error) {
+func hasExistingClaudeFiles(cfg *config.Config) (bool, error) {
 	claudeDir := config.ClaudeDir()
 	if _, err := os.Stat(claudeDir); os.IsNotExist(err) {
 		return false, nil
 	}
 
-	files, err := sync.GetLocalFiles(claudeDir, config.ScopedSyncPaths(scope))
+	files, err := sync.GetLocalFiles(claudeDir, cfg.GetEffectiveSyncPaths())
 	if err != nil {
 		return false, err
 	}
@@ -2377,7 +2377,7 @@ func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, 
 	switch choice {
 	case 0:
 		// Backup and proceed
-		backupDir, err := createBackup(syncer.Scope())
+		backupDir, err := createBackup(syncer.SyncPaths())
 		if err != nil {
 			return fmt.Errorf("failed to create backup: %w", err)
 		}
@@ -2398,7 +2398,7 @@ func handleFirstPullWithExistingFiles(ctx context.Context, syncer *sync.Syncer, 
 }
 
 // createBackup creates a backup of the current ~/.claude directory
-func createBackup(scope string) (string, error) {
+func createBackup(syncPaths []string) (string, error) {
 	claudeDir := config.ClaudeDir()
 	timestamp := time.Now().Format("20060102-150405")
 	backupDir := claudeDir + ".backup." + timestamp
@@ -2409,7 +2409,7 @@ func createBackup(scope string) (string, error) {
 	}
 
 	// Copy all syncable files to backup
-	files, err := sync.GetLocalFiles(claudeDir, config.ScopedSyncPaths(scope))
+	files, err := sync.GetLocalFiles(claudeDir, syncPaths)
 	if err != nil {
 		return "", fmt.Errorf("failed to list files: %w", err)
 	}
@@ -3187,7 +3187,7 @@ func runPathsList() error {
 		return err
 	}
 
-	mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir())
+	mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir(), cfg.Scope)
 	status := mgr.Status()
 
 	source := "default"
@@ -3195,13 +3195,41 @@ func runPathsList() error {
 		source = "config.yaml"
 	}
 
-	fmt.Printf("\n%sSync Paths%s (%s):\n", colorBold, colorReset, source)
+	scopeLabel := cfg.Scope
+	if scopeLabel == "" {
+		scopeLabel = config.ScopeFull
+	}
+
+	// List what actually syncs, not the raw config list. Under sessions scope
+	// the effective set is the intersection with SessionSyncPaths, so showing
+	// cfg.SyncPaths verbatim would advertise paths that are never uploaded.
+	effective := make(map[string]struct{})
+	for _, p := range cfg.GetEffectiveSyncPaths() {
+		effective[p] = struct{}{}
+	}
+
+	var outOfScope []string
+
+	fmt.Printf("\n%sSync Paths%s (%s, scope: %s):\n", colorBold, colorReset, source, scopeLabel)
 	for _, p := range status.SyncPaths {
+		if _, ok := effective[p]; !ok {
+			outOfScope = append(outOfScope, p)
+			continue
+		}
 		marker := colorGreen + "+" + colorReset
 		if !mgr.IsDefault(p) {
 			marker = colorCyan + "+" + colorReset + " (custom)"
 		}
 		fmt.Printf("  %s %s\n", marker, p)
+	}
+
+	if len(outOfScope) > 0 {
+		fmt.Printf("\n%sNot synced%s (outside the %q scope):\n", colorBold, colorReset, scopeLabel)
+		for _, p := range outOfScope {
+			fmt.Printf("  %s-%s %s\n", colorYellow, colorReset, p)
+		}
+		fmt.Printf("\n  These remain in config.yaml and apply again if scope is set to %q.\n",
+			config.ScopeFull)
 	}
 
 	if len(status.Excludes) > 0 {
@@ -3230,8 +3258,20 @@ conflicting exclude is automatically removed.`,
 				return err
 			}
 
-			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir())
+			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir(), cfg.Scope)
 			result := mgr.Add(args[0])
+
+			if result.Invalid != nil {
+				return fmt.Errorf("invalid sync path: %w", result.Invalid)
+			}
+
+			if result.OutOfScope {
+				fmt.Printf("%s!%s %s is outside the %q scope and would not be synced\n",
+					colorYellow, colorReset, args[0], config.ScopeSessions)
+				fmt.Printf("  Set %sscope: full%s in %s to sync paths beyond session data.\n",
+					colorCyan, colorReset, config.ConfigFilePath())
+				return nil
+			}
 
 			if result.AlreadyExists {
 				fmt.Printf("%s!%s %s is already in the sync list\n", colorYellow, colorReset, args[0])
@@ -3273,7 +3313,7 @@ Custom paths are simply removed from the list.`,
 				return err
 			}
 
-			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir())
+			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir(), cfg.Scope)
 
 			if !mgr.HasPath(args[0]) {
 				fmt.Printf("%s!%s %s is not in the sync list\n", colorYellow, colorReset, args[0])
@@ -3327,7 +3367,7 @@ Glob syntax: dir/*, dir/**, **/*.ext`,
 				return err
 			}
 
-			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir())
+			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir(), cfg.Scope)
 			result := mgr.AddExclude(args[0])
 
 			if result.IsSyncPath {
@@ -3363,7 +3403,7 @@ func pathsUnexcludeCmd() *cobra.Command {
 				return err
 			}
 
-			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir())
+			mgr := paths.NewManager(cfg.SyncPaths, cfg.Exclude, config.ClaudeDir(), cfg.Scope)
 			result := mgr.RemoveExclude(args[0])
 
 			if result.NotFound {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,7 @@ var SyncPaths = []string{
 	"tasks",
 	"history.jsonl",
 	"rules",
+	"workflows",
 }
 
 // SessionSyncPaths is the subset synced in the "sessions" scope: portable,
@@ -261,11 +262,48 @@ func (c *Config) IsLegacyConfig() bool {
 
 // GetEffectiveSyncPaths returns the paths to sync: custom SyncPaths if set,
 // otherwise the scope-based defaults.
+//
+// Scope is a ceiling, not merely a default. Under ScopeSessions the custom list
+// is intersected with SessionSyncPaths so a sync_paths entry can never widen a
+// sessions-scoped config back into non-portable trees like plugins/ (which
+// bundles node_modules and .venv). Under "full" scope the custom list wins
+// outright, since there is nothing narrower to protect.
+//
+// This matters because `claude-sync paths add|remove` materializes the entire
+// default path list into SyncPaths, so most configs carrying a sync_paths block
+// never explicitly opted into one.
+//
+// The result is never empty: an empty set would make DetectChanges observe zero
+// local files and report every tracked file as a deletion, wiping the remote on
+// the next push. If a custom list shares nothing with the scope, the scope
+// defaults are used instead.
 func (c *Config) GetEffectiveSyncPaths() []string {
-	if len(c.SyncPaths) > 0 {
+	scoped := ScopedSyncPaths(c.Scope)
+	if len(c.SyncPaths) == 0 {
+		return scoped
+	}
+
+	if c.Scope != ScopeSessions {
 		return c.SyncPaths
 	}
-	return ScopedSyncPaths(c.Scope)
+
+	allowed := make(map[string]struct{}, len(scoped))
+	for _, p := range scoped {
+		allowed[p] = struct{}{}
+	}
+
+	// Preserve the user's ordering, keeping only in-scope entries.
+	within := make([]string, 0, len(c.SyncPaths))
+	for _, p := range c.SyncPaths {
+		if _, ok := allowed[p]; ok {
+			within = append(within, p)
+		}
+	}
+
+	if len(within) == 0 {
+		return scoped
+	}
+	return within
 }
 
 // IsMCPSyncEnabled returns true if MCP sync is explicitly enabled.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -439,8 +439,17 @@ func TestGetEffectiveSyncPaths(t *testing.T) {
 			wantLen:   len(SessionSyncPaths),
 		},
 		{
-			name:      "custom SyncPaths overrides sessions scope",
+			// Scope is a ceiling: an entirely out-of-scope custom list cannot
+			// widen a sessions config, and must not collapse to an empty set
+			// either, so it falls back to the scope defaults.
+			name:      "wholly out-of-scope custom paths fall back to sessions defaults",
 			syncPaths: []string{"custom-only"},
+			scope:     ScopeSessions,
+			wantLen:   len(SessionSyncPaths),
+		},
+		{
+			name:      "custom paths are narrowed to the sessions scope",
+			syncPaths: []string{"projects", "plugins", "CLAUDE.md"},
 			scope:     ScopeSessions,
 			wantLen:   1,
 		},
@@ -454,6 +463,59 @@ func TestGetEffectiveSyncPaths(t *testing.T) {
 				t.Errorf("GetEffectiveSyncPaths() returned %d paths, want %d", len(got), tt.wantLen)
 			}
 		})
+	}
+}
+
+// TestGetEffectiveSyncPathsScopeIsCeiling guards the regression that motivated
+// wiring up the override: `paths add|remove` materializes the full default path
+// list into sync_paths, so honoring that list verbatim would silently widen a
+// sessions-scoped config back into plugins/ (node_modules, .venv) on upgrade.
+func TestGetEffectiveSyncPathsScopeIsCeiling(t *testing.T) {
+	materialized := append([]string{}, SyncPaths...)
+	materialized = append(materialized, "my-extra-file.md")
+
+	cfg := &Config{SyncPaths: materialized, Scope: ScopeSessions}
+	got := cfg.GetEffectiveSyncPaths()
+
+	for _, p := range got {
+		if p == "plugins" {
+			t.Fatalf("sessions scope leaked plugins/ via sync_paths: %v", got)
+		}
+	}
+
+	for _, p := range got {
+		var inScope bool
+		for _, s := range SessionSyncPaths {
+			if p == s {
+				inScope = true
+				break
+			}
+		}
+		if !inScope {
+			t.Errorf("path %q is outside SessionSyncPaths but was returned", p)
+		}
+	}
+
+	if len(got) == 0 {
+		t.Error("effective sync paths must never be empty: an empty set makes " +
+			"DetectChanges report every tracked file as deleted, wiping the remote")
+	}
+}
+
+// TestGetEffectiveSyncPathsAppliedByFullScope covers the originally reported
+// bug: a custom sync_paths list under the default scope must be honored.
+func TestGetEffectiveSyncPathsAppliedByFullScope(t *testing.T) {
+	cfg := &Config{SyncPaths: []string{"CLAUDE.md", "my-extra-file.md"}}
+	got := cfg.GetEffectiveSyncPaths()
+
+	var found bool
+	for _, p := range got {
+		if p == "my-extra-file.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("custom sync_paths ignored under full scope: got %v", got)
 	}
 }
 

--- a/internal/paths/manager.go
+++ b/internal/paths/manager.go
@@ -3,26 +3,46 @@
 package paths
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/tawanorg/claude-sync/internal/config"
 )
 
-// DefaultSyncPaths are the built-in paths synced by default.
-var DefaultSyncPaths = []string{
-	"CLAUDE.md",
-	"settings.json",
-	"settings.local.json",
-	"agents",
-	"commands",
-	"skills",
-	"plugins",
-	"projects",
-	"plans",
-	"tasks",
-	"history.jsonl",
-	"rules",
-	"workflows",
+// DefaultSyncPaths returns the built-in paths synced by default for the given
+// scope. It delegates to config so the paths shown by the CLI can never drift
+// from the paths the syncer actually walks — the two lists were maintained
+// separately before, which left workflows/ advertised but never synced and made
+// `paths list` report full-scope defaults to sessions-scoped users.
+func DefaultSyncPaths(scope string) []string {
+	return config.ScopedSyncPaths(scope)
+}
+
+// ValidatePath rejects sync path entries that would escape ~/.claude.
+//
+// Sync paths were a hardcoded constant until the sync_paths override was wired
+// up, so nothing validated them. They are now user-supplied input that becomes
+// a filesystem walk root on push and a write target on pull, where a traversing
+// entry would read and write outside the sync root.
+func ValidatePath(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("path cannot be empty")
+	}
+	if filepath.IsAbs(path) || strings.HasPrefix(path, "/") {
+		return fmt.Errorf("path must be relative to ~/.claude, got absolute path %q", path)
+	}
+	if vol := filepath.VolumeName(path); vol != "" {
+		return fmt.Errorf("path must be relative to ~/.claude, got %q", path)
+	}
+
+	// Clean resolves ".." segments; anything still climbing escapes the root.
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("path %q escapes ~/.claude", path)
+	}
+	return nil
 }
 
 // Manager handles sync path and exclude filter operations.
@@ -31,32 +51,38 @@ type Manager struct {
 	syncPaths  []string
 	excludes   []string
 	claudeDir  string
+	scope      string
 	defaultSet map[string]struct{}
 }
 
 // NewManager creates a Manager with the given paths and excludes.
-// If claudeDir is empty, it defaults to ~/.claude.
-func NewManager(syncPaths, excludes []string, claudeDir string) *Manager {
+// If claudeDir is empty, it defaults to ~/.claude. The scope determines which
+// path set counts as "default", so a sessions-scoped config is not shown or
+// reset against the full-scope list.
+func NewManager(syncPaths, excludes []string, claudeDir, scope string) *Manager {
 	if claudeDir == "" {
 		home, _ := os.UserHomeDir()
 		claudeDir = filepath.Join(home, ".claude")
 	}
 
+	defaults := DefaultSyncPaths(scope)
+
 	// Build default set for quick lookup
-	defaultSet := make(map[string]struct{}, len(DefaultSyncPaths))
-	for _, p := range DefaultSyncPaths {
+	defaultSet := make(map[string]struct{}, len(defaults))
+	for _, p := range defaults {
 		defaultSet[p] = struct{}{}
 	}
 
 	// Use defaults if no custom paths
 	if len(syncPaths) == 0 {
-		syncPaths = append([]string{}, DefaultSyncPaths...)
+		syncPaths = append([]string{}, defaults...)
 	}
 
 	return &Manager{
 		syncPaths:  syncPaths,
 		excludes:   excludes,
 		claudeDir:  claudeDir,
+		scope:      scope,
 		defaultSet: defaultSet,
 	}
 }
@@ -77,6 +103,11 @@ type AddResult struct {
 	AlreadyExists   bool
 	PathMissing     bool
 	ExcludesRemoved int
+	// Invalid is set when the path escapes ~/.claude; nothing was changed.
+	Invalid error
+	// OutOfScope is set when the path is not reachable under the current
+	// sessions scope, so it would be filtered out before reaching the syncer.
+	OutOfScope bool
 }
 
 // Add adds a path to the sync list.
@@ -84,6 +115,21 @@ type AddResult struct {
 // Returns details about what changed.
 func (m *Manager) Add(path string) AddResult {
 	result := AddResult{}
+
+	if err := ValidatePath(path); err != nil {
+		result.Invalid = err
+		return result
+	}
+
+	// A sessions-scoped config intersects sync_paths with SessionSyncPaths, so
+	// an out-of-scope entry would be silently dropped at sync time. Report it
+	// here rather than writing config the syncer will ignore.
+	if m.scope == config.ScopeSessions {
+		if _, inScope := m.defaultSet[path]; !inScope {
+			result.OutOfScope = true
+			return result
+		}
+	}
 
 	// Check if already in list
 	for _, p := range m.syncPaths {
@@ -244,7 +290,7 @@ func (m *Manager) RemoveExclude(pattern string) RemoveExcludeResult {
 
 // Reset restores default sync paths and clears all excludes.
 func (m *Manager) Reset() {
-	m.syncPaths = append([]string{}, DefaultSyncPaths...)
+	m.syncPaths = append([]string{}, DefaultSyncPaths(m.scope)...)
 	m.excludes = nil
 }
 

--- a/internal/paths/manager_test.go
+++ b/internal/paths/manager_test.go
@@ -4,25 +4,27 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tawanorg/claude-sync/internal/config"
 )
 
 func TestNewManager(t *testing.T) {
 	// With empty paths, should use defaults
-	m := NewManager(nil, nil, "/tmp/test")
-	if len(m.SyncPaths()) != len(DefaultSyncPaths) {
-		t.Errorf("Expected %d default paths, got %d", len(DefaultSyncPaths), len(m.SyncPaths()))
+	m := NewManager(nil, nil, "/tmp/test", config.ScopeFull)
+	if len(m.SyncPaths()) != len(DefaultSyncPaths(config.ScopeFull)) {
+		t.Errorf("Expected %d default paths, got %d", len(DefaultSyncPaths(config.ScopeFull)), len(m.SyncPaths()))
 	}
 
 	// With custom paths, should use those
 	custom := []string{"path1", "path2"}
-	m = NewManager(custom, nil, "/tmp/test")
+	m = NewManager(custom, nil, "/tmp/test", config.ScopeFull)
 	if len(m.SyncPaths()) != 2 {
 		t.Errorf("Expected 2 paths, got %d", len(m.SyncPaths()))
 	}
 }
 
 func TestAddPath(t *testing.T) {
-	m := NewManager([]string{"existing"}, nil, "/tmp/nonexistent")
+	m := NewManager([]string{"existing"}, nil, "/tmp/nonexistent", config.ScopeFull)
 
 	// Add new path
 	result := m.Add("newpath")
@@ -47,7 +49,7 @@ func TestAddPath(t *testing.T) {
 }
 
 func TestAddPathRemovesConflictingExcludes(t *testing.T) {
-	m := NewManager([]string{"a"}, []string{"b", "b/*", "c/**"}, "/tmp/test")
+	m := NewManager([]string{"a"}, []string{"b", "b/*", "c/**"}, "/tmp/test", config.ScopeFull)
 
 	// Add 'b' should remove 'b' and 'b/*' excludes
 	result := m.Add("b")
@@ -63,7 +65,7 @@ func TestAddPathRemovesConflictingExcludes(t *testing.T) {
 }
 
 func TestRemovePath(t *testing.T) {
-	m := NewManager([]string{"CLAUDE.md", "custom"}, nil, "/tmp/test")
+	m := NewManager([]string{"CLAUDE.md", "custom"}, nil, "/tmp/test", config.ScopeFull)
 
 	// Remove non-existent
 	result := m.Remove("nonexistent")
@@ -84,7 +86,7 @@ func TestRemovePath(t *testing.T) {
 	}
 
 	// Remove default path
-	m = NewManager([]string{"CLAUDE.md"}, nil, "/tmp/test")
+	m = NewManager([]string{"CLAUDE.md"}, nil, "/tmp/test", config.ScopeFull)
 	result = m.Remove("CLAUDE.md")
 	if !result.Removed {
 		t.Error("Expected Removed=true")
@@ -107,7 +109,7 @@ func TestRemoveDefaultPathAddsExclude(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := NewManager(nil, nil, claudeDir)
+	m := NewManager(nil, nil, claudeDir, config.ScopeFull)
 
 	// Remove 'agents' (a directory)
 	result := m.Remove("agents")
@@ -122,7 +124,7 @@ func TestRemoveDefaultPathAddsExclude(t *testing.T) {
 }
 
 func TestAddExclude(t *testing.T) {
-	m := NewManager([]string{"plugins"}, []string{"existing/*"}, "/tmp/test")
+	m := NewManager([]string{"plugins"}, []string{"existing/*"}, "/tmp/test", config.ScopeFull)
 
 	// Add new exclude
 	result := m.AddExclude("plugins/**/node_modules/**")
@@ -147,7 +149,7 @@ func TestAddExclude(t *testing.T) {
 }
 
 func TestRemoveExclude(t *testing.T) {
-	m := NewManager(nil, []string{"a/*", "b/**"}, "/tmp/test")
+	m := NewManager(nil, []string{"a/*", "b/**"}, "/tmp/test", config.ScopeFull)
 
 	// Remove existing
 	result := m.RemoveExclude("a/*")
@@ -170,12 +172,13 @@ func TestReset(t *testing.T) {
 		[]string{"custom1", "custom2"},
 		[]string{"exclude1", "exclude2"},
 		"/tmp/test",
+		config.ScopeFull,
 	)
 
 	m.Reset()
 
-	if len(m.SyncPaths()) != len(DefaultSyncPaths) {
-		t.Errorf("Expected %d default paths after reset, got %d", len(DefaultSyncPaths), len(m.SyncPaths()))
+	if len(m.SyncPaths()) != len(DefaultSyncPaths(config.ScopeFull)) {
+		t.Errorf("Expected %d default paths after reset, got %d", len(DefaultSyncPaths(config.ScopeFull)), len(m.SyncPaths()))
 	}
 	if len(m.Excludes()) != 0 {
 		t.Errorf("Expected 0 excludes after reset, got %d", len(m.Excludes()))
@@ -183,7 +186,7 @@ func TestReset(t *testing.T) {
 }
 
 func TestIsDefault(t *testing.T) {
-	m := NewManager(nil, nil, "/tmp/test")
+	m := NewManager(nil, nil, "/tmp/test", config.ScopeFull)
 
 	if !m.IsDefault("CLAUDE.md") {
 		t.Error("CLAUDE.md should be a default")
@@ -198,7 +201,7 @@ func TestIsDefault(t *testing.T) {
 
 func TestStatus(t *testing.T) {
 	// Default state
-	m := NewManager(nil, nil, "/tmp/test")
+	m := NewManager(nil, nil, "/tmp/test", config.ScopeFull)
 	status := m.Status()
 	if status.IsCustomized {
 		t.Error("Default manager should not be customized")
@@ -218,7 +221,7 @@ func TestStatus(t *testing.T) {
 	}
 
 	// Remove default and check removed defaults tracking
-	m = NewManager(nil, []string{"CLAUDE.md/*"}, "/tmp/test")
+	m = NewManager(nil, []string{"CLAUDE.md/*"}, "/tmp/test", config.ScopeFull)
 	status = m.Status()
 	if len(status.RemovedDefaults) != 1 {
 		t.Errorf("Expected 1 removed default, got %d", len(status.RemovedDefaults))
@@ -226,7 +229,7 @@ func TestStatus(t *testing.T) {
 }
 
 func TestHasPath(t *testing.T) {
-	m := NewManager([]string{"a", "b"}, nil, "/tmp/test")
+	m := NewManager([]string{"a", "b"}, nil, "/tmp/test", config.ScopeFull)
 
 	if !m.HasPath("a") {
 		t.Error("Should have path 'a'")
@@ -237,7 +240,7 @@ func TestHasPath(t *testing.T) {
 }
 
 func TestHasExclude(t *testing.T) {
-	m := NewManager(nil, []string{"*.tmp", "cache/**"}, "/tmp/test")
+	m := NewManager(nil, []string{"*.tmp", "cache/**"}, "/tmp/test", config.ScopeFull)
 
 	if !m.HasExclude("*.tmp") {
 		t.Error("Should have exclude '*.tmp'")
@@ -255,7 +258,7 @@ func TestIntegrationWorkflow(t *testing.T) {
 	}
 
 	// Start fresh
-	m := NewManager(nil, nil, claudeDir)
+	m := NewManager(nil, nil, claudeDir, config.ScopeFull)
 
 	// 1. Remove a default path
 	result := m.Remove("history.jsonl")
@@ -273,7 +276,7 @@ func TestIntegrationWorkflow(t *testing.T) {
 	// 2. Simulate re-adding with the saved state (like after config reload)
 	// This simulates: user removed history.jsonl, config was saved with
 	// modified syncPaths (without history.jsonl) and excludes (with history.jsonl)
-	m = NewManager(currentPaths, currentExcludes, claudeDir)
+	m = NewManager(currentPaths, currentExcludes, claudeDir, config.ScopeFull)
 
 	// Verify history.jsonl is NOT in sync paths but IS in excludes
 	if m.HasPath("history.jsonl") {

--- a/internal/paths/validate_test.go
+++ b/internal/paths/validate_test.go
@@ -1,0 +1,96 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/tawanorg/claude-sync/internal/config"
+)
+
+func TestValidatePath(t *testing.T) {
+	valid := []string{
+		"CLAUDE.md",
+		"agents",
+		"projects/foo",
+		"a/b/c.json",
+		"./CLAUDE.md",
+	}
+	for _, p := range valid {
+		if err := ValidatePath(p); err != nil {
+			t.Errorf("ValidatePath(%q) = %v, want nil", p, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"   ",
+		"..",
+		"../.ssh",
+		"../../etc/passwd",
+		"projects/../../.ssh/id_rsa",
+		"/etc/passwd",
+		"/",
+	}
+	for _, p := range invalid {
+		if err := ValidatePath(p); err == nil {
+			t.Errorf("ValidatePath(%q) = nil, want error", p)
+		}
+	}
+}
+
+// TestAddRejectsTraversal ensures the CLI cannot persist a sync path that would
+// read outside ~/.claude on push or write outside it on pull.
+func TestAddRejectsTraversal(t *testing.T) {
+	m := NewManager(nil, nil, "/tmp/test", config.ScopeFull)
+	before := len(m.SyncPaths())
+
+	result := m.Add("../.ssh")
+	if result.Invalid == nil {
+		t.Error("Add(\"../.ssh\") should be rejected")
+	}
+	if result.Added {
+		t.Error("traversing path must not be added")
+	}
+	if len(m.SyncPaths()) != before {
+		t.Errorf("sync paths mutated on rejected add: %v", m.SyncPaths())
+	}
+}
+
+// TestAddRejectsOutOfScopePathUnderSessions prevents writing config that the
+// syncer would silently discard, since sessions scope intersects sync_paths.
+func TestAddRejectsOutOfScopePathUnderSessions(t *testing.T) {
+	m := NewManager(nil, nil, "/tmp/test", config.ScopeSessions)
+
+	result := m.Add("plugins")
+	if !result.OutOfScope {
+		t.Error("adding plugins under sessions scope should report OutOfScope")
+	}
+	if result.Added {
+		t.Error("out-of-scope path must not be added")
+	}
+
+	// An in-scope path is still addable.
+	if got := m.Add("projects"); got.OutOfScope {
+		t.Error("projects is within sessions scope and should be addable")
+	}
+}
+
+// TestManagerDefaultsTrackScope guards the drift that left workflows/ shown by
+// `paths list` but never synced, and full-scope defaults shown to sessions users.
+func TestManagerDefaultsTrackScope(t *testing.T) {
+	full := NewManager(nil, nil, "/tmp/test", config.ScopeFull)
+	if len(full.SyncPaths()) != len(config.SyncPaths) {
+		t.Errorf("full scope defaults = %d paths, want %d (config.SyncPaths)",
+			len(full.SyncPaths()), len(config.SyncPaths))
+	}
+
+	sessions := NewManager(nil, nil, "/tmp/test", config.ScopeSessions)
+	if len(sessions.SyncPaths()) != len(config.SessionSyncPaths) {
+		t.Errorf("sessions scope defaults = %d paths, want %d (config.SessionSyncPaths)",
+			len(sessions.SyncPaths()), len(config.SessionSyncPaths))
+	}
+	for _, p := range sessions.SyncPaths() {
+		if p == "plugins" {
+			t.Error("sessions scope must not list plugins/ as a default")
+		}
+	}
+}

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -216,6 +217,17 @@ func HashFile(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
+// isWithin reports whether target is root itself or lives underneath it.
+// Both are cleaned first so ".." segments cannot slip through.
+func isWithin(root, target string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(target))
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, "../"))
+}
+
 func GetLocalFiles(claudeDir string, syncPaths []string, excludeFn ...func(string) bool) (map[string]os.FileInfo, error) {
 	files := make(map[string]os.FileInfo)
 
@@ -227,6 +239,13 @@ func GetLocalFiles(claudeDir string, syncPaths []string, excludeFn ...func(strin
 
 	for _, syncPath := range syncPaths {
 		fullPath := filepath.Join(claudeDir, syncPath)
+
+		// Sync paths are user-configurable via sync_paths, so a traversing
+		// entry could otherwise walk outside the sync root and turn files like
+		// ~/.ssh/id_rsa into remote objects. Skip anything that escapes.
+		if !isWithin(claudeDir, fullPath) {
+			continue
+		}
 
 		info, err := os.Stat(fullPath)
 		if os.IsNotExist(err) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -149,15 +149,23 @@ func (s *Syncer) isExcluded(relPath string) bool {
 	return s.cfg.IsExcluded(relPath)
 }
 
-// syncPaths returns the set of ~/.claude paths to sync, honoring the
-// configured scope ("full" by default, or "sessions" for portable data only).
+// syncPaths returns the set of ~/.claude paths to sync, honoring both the
+// configured scope ("full" by default, or "sessions" for portable data only)
+// and any sync_paths override, with scope acting as a ceiling.
 func (s *Syncer) syncPaths() []string {
-	return config.ScopedSyncPaths(s.cfg.Scope)
+	return s.cfg.GetEffectiveSyncPaths()
 }
 
 // Scope returns the configured sync scope (empty means the default "full").
 func (s *Syncer) Scope() string {
 	return s.cfg.Scope
+}
+
+// SyncPaths returns the effective ~/.claude paths this syncer operates on, so
+// callers such as the pre-pull backup cover exactly the set that pull can
+// overwrite rather than recomputing it from scope alone.
+func (s *Syncer) SyncPaths() []string {
+	return s.syncPaths()
 }
 
 func (s *Syncer) log(format string, args ...interface{}) {

--- a/internal/sync/syncpaths_test.go
+++ b/internal/sync/syncpaths_test.go
@@ -1,0 +1,112 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tawanorg/claude-sync/internal/config"
+)
+
+// TestSyncerHonorsCustomSyncPaths is the regression test for issue #64: the
+// sync_paths override was wired into Config but never read by the syncer, so a
+// user-supplied path list was silently ignored by push, status, and diff.
+func TestSyncerHonorsCustomSyncPaths(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"CLAUDE.md", "my-extra-file.md", "unlisted.md"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{SyncPaths: []string{"CLAUDE.md", "my-extra-file.md"}}
+	s := &Syncer{cfg: cfg, claudeDir: dir}
+
+	got, err := GetLocalFiles(dir, s.syncPaths(), s.isExcluded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := got["my-extra-file.md"]; !ok {
+		t.Errorf("custom sync_paths entry not synced; got %v", sortedKeys(got))
+	}
+	if _, ok := got["unlisted.md"]; ok {
+		t.Errorf("file outside sync_paths was synced; got %v", sortedKeys(got))
+	}
+}
+
+// TestSyncerScopeCeilingBlocksPluginsLeak verifies that a materialized
+// sync_paths list cannot widen a sessions-scoped config back into plugins/,
+// which bundles non-portable node_modules and .venv trees.
+func TestSyncerScopeCeilingBlocksPluginsLeak(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "plugins", "node_modules"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plugins", "node_modules", "big.js"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "projects"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "projects", "a.jsonl"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Scope:     config.ScopeSessions,
+		SyncPaths: append([]string{}, config.SyncPaths...), // what `paths add` writes
+	}
+	s := &Syncer{cfg: cfg, claudeDir: dir}
+
+	got, err := GetLocalFiles(dir, s.syncPaths(), s.isExcluded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for p := range got {
+		if filepath.ToSlash(p) == "plugins/node_modules/big.js" {
+			t.Fatalf("sessions scope uploaded plugins/: %v", sortedKeys(got))
+		}
+	}
+	if _, ok := got["projects/a.jsonl"]; !ok {
+		t.Errorf("in-scope path missing: %v", sortedKeys(got))
+	}
+}
+
+// TestGetLocalFilesRejectsTraversingSyncPath ensures a sync_paths entry cannot
+// walk outside ~/.claude. Sync paths became user-controlled input once the
+// override was honored, and a traversing entry would otherwise turn files like
+// ~/.ssh/id_rsa into remote objects.
+func TestGetLocalFilesRejectsTraversingSyncPath(t *testing.T) {
+	root := t.TempDir()
+	claudeDir := filepath.Join(root, ".claude")
+	if err := os.MkdirAll(claudeDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	secretDir := filepath.Join(root, ".ssh")
+	if err := os.MkdirAll(secretDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secretDir, "id_rsa"), []byte("PRIVATE"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetLocalFiles(claudeDir, []string{"../.ssh", "../.ssh/id_rsa"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("traversing sync path escaped the sync root: %v", sortedKeys(got))
+	}
+}
+
+func sortedKeys(m map[string]os.FileInfo) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Fixes #64 — `Syncer.syncPaths()` called `config.ScopedSyncPaths(cfg.Scope)` directly and never consulted `GetEffectiveSyncPaths()`, so a user-supplied `sync_paths:` list was silently ignored by push, status, and diff. It now reads the effective set.
- Made scope a **ceiling rather than a default**. The one-line fix suggested in the issue would have regressed worse than the bug it fixes: `GetEffectiveSyncPaths()` checked `len(SyncPaths) > 0` before scope, and because `paths add|remove` materializes the *entire* default list into `sync_paths`, any user who had ever run a `paths` command would have started uploading `plugins/` (node_modules, .venv) from a `scope: sessions` config that deliberately excludes it. Sessions now intersects; full scope still overrides freely.
- Unified the two divergent default path lists, which was the actual root cause. `paths.DefaultSyncPaths` carried `workflows` while `config.SyncPaths` did not, so `~/.claude/workflows/` was advertised by `paths list` but never synced (since v1.14.0), and sessions-scoped users were shown full-scope defaults. `internal/paths` now derives from `config.ScopedSyncPaths(scope)`.
- Guarded a remote-wipe footgun found while implementing: an empty effective path set makes `DetectChanges` see zero local files and mark every tracked file as a deletion. An intersection matching nothing now falls back to scope defaults.
- Added path traversal validation. Sync paths were a hardcoded constant and therefore trusted; honoring the override makes them user input that becomes a filesystem walk root on push and a write target on pull (`sync.go:417`, `:486`). Rejected in `ValidatePath` and guarded again in `GetLocalFiles`.
- `paths list` now reports what actually syncs, with out-of-scope entries listed separately and left intact in config, instead of advertising paths that scope filters out.
- `hasExistingClaudeFiles` and `createBackup` computed their file set from scope alone, so the pre-pull backup could miss files that pull would overwrite. Both now use the effective path set.

## Verification

- `make check` passes; coverage stays above the 60% CI gate (config 74.2%, paths 95.1%, sync 74.2%).
- The regression test was confirmed to **fail against the pre-fix code** and pass after, rather than only passing on the new code.
- Verified end-to-end against a real binary: the issue's exact repro now works, traversal is rejected, sessions scope holds the line on `plugins/`, and `paths remove` does not truncate stored config (13 → 12 entries, out-of-scope entries preserved).

## Notes for review

- **Typed `feat:` rather than `fix:` deliberately.** `workflows/` begins syncing on full scope — intended since #48 but never active, so it is a real behavior change on upgrade and users should get it on a minor bump, not a patch. Worth a CHANGELOG callout.
- **No migration included** to clear materialized `sync_paths`. The ceiling makes one unnecessary for safety, but full-scope users who ran `paths add` still carry a frozen snapshot of the v1.14 defaults and won't pick up future additions to `config.SyncPaths`. The proper fix is storing a delta (`sync_paths_add`/`sync_paths_remove`) applied on top of the scope set — suggest a follow-up issue rather than folding it in here.

Thanks to @RLT-edward-curt for the precise diagnosis and repro in #64.