### PR TITLE
chore: ignore root-level claude-sync build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ bin/claude-sync
 bin/claude-sync.exe
 bin/claude-sync-*
 
+# Root-level build output. `make build` targets ./bin, but a plain
+# `go build -o claude-sync ./cmd/claude-sync` drops a ~55MB binary here,
+# which a `git add -A` would commit into history permanently.
+/claude-sync
+/claude-sync.exe
+
 # Platform package binaries (added during publish, not committed)
 npm/*/claude-sync
 npm/*/claude-sync.exe


### PR DESCRIPTION
## Summary

- `.gitignore` covers `bin/claude-sync` and `npm/*/claude-sync`, but nothing ignores a binary built to the repo root — so `go build -o claude-sync ./cmd/claude-sync` leaves a ~55MB Mach-O next to `go.mod` where `git status` shows it as untracked.
- One `git add -A` would commit it into history, bloating every clone permanently and requiring a history rewrite to undo. Adds `/claude-sync` and `/claude-sync.exe`, anchored to the root so they don't shadow anything nested.
- Found while checking the working tree after #65 — the binary was already sitting there untracked.

No functional change; `make check` passes.