### PR TITLE
fix(npm): repair broken publish pipeline and installer fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
       - name: Build
         run: go build ./...
 
+      # The npm installer is the primary distribution path but has no Go
+      # coverage. Its redirect allowlist broke silently once already.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Test npm installer
+        run: node --test
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,11 @@ jobs:
             GOOS=windows GOARCH=arm64 go build -ldflags "$LDFLAGS" -o bin/claude-sync-windows-arm64.exe ./cmd/claude-sync
           fi
 
+      # Not continue-on-error: a silent npm publish failure left the registry
+      # 9 minor versions behind the git tags for 16 weeks. A failed publish must
+      # fail the release.
       - name: Publish platform packages to npm
         if: success()
-        continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |

--- a/.npmignore
+++ b/.npmignore
@@ -35,3 +35,6 @@ testdata/
 !package.json
 !README.md
 !LICENSE
+
+# JS tests (not shipped)
+*.test.js

--- a/install.js
+++ b/install.js
@@ -6,7 +6,13 @@ const fs = require("fs");
 const path = require("path");
 
 const REPO = "tawanorg/claude-sync";
-const ALLOWED_HOSTS = ["github.com", "objects.githubusercontent.com"];
+// Release downloads start at github.com and redirect to a GitHub-run asset CDN.
+// That CDN host is not stable — it was objects.githubusercontent.com and is now
+// release-assets.githubusercontent.com — so pinning exact hostnames breaks the
+// installer whenever GitHub moves it. Match the githubusercontent.com parent
+// domain instead, which stays scoped to GitHub-controlled hosts.
+const ALLOWED_HOSTS = ["github.com", "api.github.com"];
+const ALLOWED_HOST_SUFFIX = ".githubusercontent.com";
 const MAX_REDIRECTS = 5;
 
 function getPlatform() {
@@ -89,7 +95,17 @@ function getChecksumsUrl(version) {
 function isAllowedHost(url) {
   try {
     const parsed = new URL(url);
-    return ALLOWED_HOSTS.includes(parsed.hostname);
+    // https only: without this an http:// redirect to an allowed host would
+    // downgrade the transport and defeat the checksum's purpose.
+    if (parsed.protocol !== "https:") {
+      return false;
+    }
+    if (ALLOWED_HOSTS.includes(parsed.hostname)) {
+      return true;
+    }
+    // Suffix match, not endsWith on the bare domain: "evilgithubusercontent.com"
+    // must not pass, so the leading dot is required.
+    return parsed.hostname.endsWith(ALLOWED_HOST_SUFFIX);
   } catch {
     return false;
   }
@@ -222,12 +238,50 @@ function hashFile(filePath) {
   });
 }
 
+// Platform-specific packages ship the binary as an optionalDependency, which
+// installs faster and works offline. This download is the fallback for when one
+// of them is missing — a platform npm publish that failed, an install with
+// --no-optional, or a platform we have not packaged. Both paths write to the
+// same place bin/claude-sync.js looks, so either satisfies the wrapper.
+const PLATFORM_PACKAGES = {
+  "darwin-arm64": "@tawandotorg/claude-sync-darwin-arm64",
+  "darwin-x64": "@tawandotorg/claude-sync-darwin-x64",
+  "linux-arm64": "@tawandotorg/claude-sync-linux-arm64",
+  "linux-x64": "@tawandotorg/claude-sync-linux-x64",
+  "win32-arm64": "@tawandotorg/claude-sync-win32-arm64",
+  "win32-x64": "@tawandotorg/claude-sync-win32-x64",
+};
+
+// platformPackageBinary returns the path to a binary already provided by the
+// matching optionalDependency, or null when none is installed.
+function platformPackageBinary() {
+  const packageName = PLATFORM_PACKAGES[`${process.platform}-${process.arch}`];
+  if (!packageName) {
+    return null;
+  }
+
+  try {
+    const packageDir = path.dirname(require.resolve(`${packageName}/package.json`));
+    const binaryName = process.platform === "win32" ? "claude-sync.exe" : "claude-sync";
+    const binaryPath = path.join(packageDir, binaryName);
+    return fs.existsSync(binaryPath) ? binaryPath : null;
+  } catch (e) {
+    return null;
+  }
+}
+
 async function install() {
   const binDir = path.join(__dirname, "bin");
   const platform = getPlatform();
   const binaryName = platform === "windows" ? "claude-sync.exe" : "claude-sync";
   const binaryPath = path.join(binDir, binaryName);
   const assetName = getBinaryName();
+
+  const fromPackage = platformPackageBinary();
+  if (fromPackage) {
+    console.log(`✓ Using platform package binary: ${fromPackage}`);
+    return;
+  }
 
   // Create bin directory
   if (!fs.existsSync(binDir)) {

--- a/install.test.js
+++ b/install.test.js
@@ -1,0 +1,60 @@
+// Tests for the npm postinstall installer.
+//
+// These exist because the redirect allowlist silently broke the installer: it
+// pinned objects.githubusercontent.com, GitHub moved release downloads to
+// release-assets.githubusercontent.com, and every install failed. Nobody
+// noticed for months because npm publishing was also broken, so the change
+// never reached a user. Run with: node --test
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// install.js runs its install() on require, so pull the pure helpers out of the
+// source rather than importing it.
+function loadHelper(name) {
+  const src = fs.readFileSync(path.join(__dirname, "install.js"), "utf8");
+  const consts = src.match(
+    /const ALLOWED_HOSTS = \[[^\]]*\];\nconst ALLOWED_HOST_SUFFIX = "[^"]*";/
+  );
+  const fn = src.match(new RegExp(`function ${name}\\(url\\) \\{[\\s\\S]*?\\n\\}`));
+  assert.ok(consts, "ALLOWED_HOSTS/ALLOWED_HOST_SUFFIX not found in install.js");
+  assert.ok(fn, `${name} not found in install.js`);
+  // eslint-disable-next-line no-eval
+  return eval(`${consts[0]}\n${fn[0]}\n${name}`);
+}
+
+test("isAllowedHost accepts GitHub release download hosts", () => {
+  const isAllowedHost = loadHelper("isAllowedHost");
+
+  for (const url of [
+    "https://github.com/tawanorg/claude-sync/releases/download/v1.0.0/x",
+    "https://api.github.com/repos/tawanorg/claude-sync/releases/latest",
+    // The historical asset CDN.
+    "https://objects.githubusercontent.com/foo",
+    // The current asset CDN — the host whose absence broke every install.
+    "https://release-assets.githubusercontent.com/foo",
+  ]) {
+    assert.strictEqual(isAllowedHost(url), true, `should allow ${url}`);
+  }
+});
+
+test("isAllowedHost rejects lookalike and untrusted hosts", () => {
+  const isAllowedHost = loadHelper("isAllowedHost");
+
+  for (const url of [
+    // Suffix match must require the leading dot.
+    "https://evilgithubusercontent.com/foo",
+    // Domain must be the parent, not a prefix of someone else's.
+    "https://githubusercontent.com.evil.com/foo",
+    "https://github.com.evil.com/foo",
+    "https://evil.com/foo",
+    // A downgrade to http would defeat the point of verifying a checksum.
+    "http://github.com/foo",
+    "http://release-assets.githubusercontent.com/foo",
+    "not a url",
+  ]) {
+    assert.strictEqual(isAllowedHost(url), false, `should reject ${url}`);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "bin": {
     "claude-sync": "./bin/claude-sync.js"
   },
+  "scripts": {
+    "postinstall": "node install.js",
+    "test": "node --test"
+  },
   "keywords": [
     "claude",
     "claude-code",

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -12,6 +12,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 NPM_DIR="$ROOT_DIR/npm"
 
+# Platform packages that failed to publish, reported at the end so one bad
+# platform does not hide the others or block the root package. Kept as a plain
+# string rather than an array: this script runs under `set -u`, where expanding
+# an empty array is an error on some bash versions.
+FAILED_PLATFORMS=""
+
 # Map: npm platform → Go binary name
 declare -A PLATFORM_MAP=(
   ["darwin-arm64"]="claude-sync-darwin-arm64"
@@ -54,8 +60,18 @@ for platform in "${!PLATFORM_MAP[@]}"; do
   # Update version in package.json
   cd "$pkg_dir"
   npm version "$VERSION" --no-git-tag-version --allow-same-version 2>/dev/null
-  npm publish --access public
-  echo "  Published!"
+
+  # A platform publish must not abort the run. The root package carries a
+  # postinstall that downloads the binary from GitHub Releases, so it is still
+  # worth publishing even when a platform package fails — users fall back
+  # instead of getting nothing. Failures are collected and re-raised at the end
+  # so CI still goes red.
+  if npm publish --access public; then
+    echo "  Published!"
+  else
+    echo "  ERROR: failed to publish @tawandotorg/claude-sync-${platform}@${VERSION}"
+    FAILED_PLATFORMS="$FAILED_PLATFORMS $platform"
+  fi
 
   # Clean up binary (don't commit binaries)
   rm -f "$pkg_dir/$dst_binary"
@@ -72,5 +88,23 @@ done
 rm -f package.json.bak
 
 npm version "$VERSION" --no-git-tag-version --allow-same-version 2>/dev/null
-npm publish --access public
-echo "Published @tawandotorg/claude-sync@${VERSION}!"
+
+ROOT_FAILED=0
+if npm publish --access public; then
+  echo "Published @tawandotorg/claude-sync@${VERSION}!"
+else
+  echo "ERROR: failed to publish @tawandotorg/claude-sync@${VERSION}"
+  ROOT_FAILED=1
+fi
+
+if [ -n "$FAILED_PLATFORMS" ]; then
+  echo
+  echo "Platform packages that failed to publish:$FAILED_PLATFORMS"
+  echo "A 404 on PUT for a package that has never been published usually means"
+  echo "NPM_TOKEN cannot create new packages in the @tawandotorg scope — grant"
+  echo "the token read/write on the whole scope, not just existing packages."
+fi
+
+if [ -n "$FAILED_PLATFORMS" ] || [ "$ROOT_FAILED" -eq 1 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

npm publishing has been failing **silently since 2026-04-07**. The registry is at `1.8.1` while git tags are at `v1.17.0` — nine minor releases that never reached the primary install channel, including the `/resume` history fix and the `sync_paths` fix.

| Channel | Version |
|---|---|
| git tags / GitHub Releases | v1.17.0 |
| npm `@tawandotorg/claude-sync` | 1.8.1 (2026-04-06) |
| `@tawandotorg/claude-sync-*` platform packages | never published |

Three faults, each of which hid the next:

- **`continue-on-error: true`** on the publish step meant a failed publish still reported the release green. That is why this went unnoticed for 16 weeks. Removed.
- **`publish-npm.sh` runs under `set -e`**, so the first platform-package E404 aborted the script *before the root package was published* — the direct cause of the root being stuck at 1.8.1. Platform failures are now collected and re-raised at the end, so one bad platform blocks neither the others nor the root package, and CI still goes red.
- **`install.js` pinned its redirect allowlist to `objects.githubusercontent.com`.** GitHub now serves release assets from `release-assets.githubusercontent.com`, so every download failed *and checksum verification was silently skipped* along the way. Now matches the `githubusercontent.com` parent domain and requires https. Added 2026-07-09, three months after the last successful publish, so it never reached a user.

Also restores `postinstall: node install.js` as a fallback alongside the platform packages, per the chosen design: `install.js` returns early when the matching `optionalDependency` already supplied the binary, and otherwise downloads from GitHub Releases. A platform package that fails to publish now degrades to a download instead of leaving no binary at all.

## Verification

- Both install paths exercised for real, not reasoned about:
  - platform package present → skips download, exits 0, no network
  - platform package absent → downloads v1.17.0, **checksum verified**, `./bin/claude-sync --version` → `claude-sync version 1.17.0`
- 9 host-allowlist cases under `node --test`, including `evilgithubusercontent.com`, `githubusercontent.com.evil.com`, `github.com.evil.com`, and http downgrade — all correctly rejected. Wired into CI, since the installer is the primary distribution path and had no test coverage.
- `bash -n`, `node --check`, YAML and JSON parse clean; `make check` passes.

## Action required that this PR cannot do

The underlying E404 is a credentials problem. `NPM_TOKEN` can write the existing `@tawandotorg/claude-sync` but **cannot create new packages in the `@tawandotorg` scope** — npm returns 404 rather than 403 to avoid leaking package existence.

Rotate it to a granular token with **read/write on the whole `@tawandotorg` scope**, not just selected packages. Until then, releases will now fail loudly instead of silently — which is the intended behaviour, but expect red release runs until the token is replaced.

## Reviewer note

Removing `continue-on-error` means the later "Publish to GitHub Packages" step (`if: success()`) is now skipped when the npm publish fails. I left that as-is deliberately: a half-published release shouldn't propagate to a secondary registry. Easy to make the two channels independent if you'd rather.