### PR TITLE
fix(sync): never sync per-machine debris (.lock and .conflict artifacts)

### DIFF
--- a/internal/sync/debris_test.go
+++ b/internal/sync/debris_test.go
@@ -1,0 +1,86 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tawanorg/claude-sync/internal/config"
+)
+
+func TestIsExcludedSkipsPerMachineDebris(t *testing.T) {
+	s := &Syncer{cfg: &config.Config{}}
+
+	excluded := []string{
+		"tasks/6bf39315-3333-4394-86bb-2d57f8759b5a/.lock",
+		".lock",
+		"projects/p1/sess.jsonl.conflict.20260729-145427",
+		"tasks/x/3.json.conflict.20260101-000000",
+	}
+	for _, p := range excluded {
+		if !s.isExcluded(p) {
+			t.Errorf("expected %q to be excluded as per-machine debris", p)
+		}
+	}
+
+	// Real data must never be caught. The .conflict rule in particular is
+	// anchored on the exact timestamp format this tool writes, because
+	// excluding an already-tracked file prunes it from the bucket on the
+	// next push — a loose pattern would delete user data remotely.
+	kept := []string{
+		"projects/p1/sess.jsonl",
+		"tasks/x/3.json",
+		"CLAUDE.md",
+		"projects/notes.conflict.md",              // ".conflict." but not our artifact
+		"projects/p1/my.conflict.2026.txt",        // wrong timestamp shape
+		"projects/p1/sess.jsonl.conflict.2026072", // truncated timestamp
+		"projects/lockfiles/package.lock",         // ends in .lock but is not a bare .lock
+		"projects/p1/.lockfile",
+	}
+	for _, p := range kept {
+		if s.isExcluded(p) {
+			t.Errorf("expected %q NOT to be excluded", p)
+		}
+	}
+}
+
+func TestIsExcludedStillHonorsUserPatterns(t *testing.T) {
+	s := &Syncer{cfg: &config.Config{Exclude: []string{"**/*.tmp"}}}
+	if !s.isExcluded("projects/p1/scratch.tmp") {
+		t.Error("user exclude patterns must still apply")
+	}
+	if s.isExcluded("projects/p1/keep.txt") {
+		t.Error("unrelated file must not be excluded")
+	}
+}
+
+func TestPushSkipsDebrisFiles(t *testing.T) {
+	env := setupTestEnv(t)
+	ctx := context.Background()
+
+	writeFile(t, env.claudeDir, "projects/p1/sess.jsonl", "{\"uuid\":\"u1\"}\n")
+	writeFile(t, env.claudeDir, "tasks/t1/.lock", "")
+	writeFile(t, env.claudeDir, "projects/p1/sess.jsonl.conflict.20260729-145427", "stale remote copy\n")
+
+	result, err := env.syncer.Push(ctx)
+	if err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+	if len(result.Uploaded) != 1 || result.Uploaded[0] != "projects/p1/sess.jsonl" {
+		t.Errorf("only the transcript should upload, got %v", result.Uploaded)
+	}
+
+	objs, err := env.store.ListUserObjects(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Errorf("expected 1 remote object, got %d: %v", len(objs), objs)
+	}
+
+	// The debris stays on disk; it is simply never published.
+	if _, err := os.Stat(filepath.Join(env.claudeDir, "tasks", "t1", ".lock")); err != nil {
+		t.Errorf("local .lock must not be removed: %v", err)
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,14 @@ import (
 )
 
 const defaultWorkers = 10
+
+// conflictArtifactRe matches only this tool's own conflict artifacts
+// (<name>.conflict.<yyyymmdd>-<hhmmss>, the format handleConflict writes),
+// never user files that merely contain ".conflict." in their names. The
+// anchoring matters: excluding a path that is already tracked in state makes
+// the next push prune it from the bucket, so a loose pattern would turn into
+// remote deletion of real data.
+var conflictArtifactRe = regexp.MustCompile(`\.conflict\.\d{8}-\d{6}$`)
 
 // maxDecompressedSize is the maximum allowed size for decompressed data (500MB).
 // This prevents decompression bomb attacks from consuming excessive memory.
@@ -146,6 +155,15 @@ func (s *Syncer) progress(event ProgressEvent) {
 }
 
 func (s *Syncer) isExcluded(relPath string) bool {
+	// Per-machine debris never syncs, regardless of user excludes. A .lock is
+	// a local process lock — on another machine it is indistinguishable from a
+	// lock genuinely held there. A .conflict.<ts> file is this tool's own local
+	// recovery artifact; uploading it replicates the artifact to every machine,
+	// where each copy can itself be re-detected and spawn further ones.
+	base := filepath.Base(relPath)
+	if base == ".lock" || conflictArtifactRe.MatchString(base) {
+		return true
+	}
 	return s.cfg.IsExcluded(relPath)
 }
 


### PR DESCRIPTION
Fixes #71. Independent of #77 — different function, no shared symbols, either can merge first.

## The problem

Two classes of local-only file are uploaded and replicated to every machine.

**`.lock`** — Claude Code writes a zero-byte lock per task directory (`tasks/<id>/.lock`). A lock represents a process holding a resource *on one machine*. Replicated elsewhere it carries no pid, no hostname, nothing: it is indistinguishable from a lock genuinely held there, and it outlives the process that created it by weeks. Across three synced machines we had 12 of them in the bucket, the oldest about four weeks old.

**`.conflict.<timestamp>`** — `handleConflict` writes the remote copy next to the original:

```go
conflictPath := relativePath + ".conflict." + time.Now().Format("20060102-150405")
```

That path is inside a synced directory, so the recovery artifact is itself uploaded. Each replica can then be re-detected on another machine and produce further artifacts. We accumulated 92 in about a week, including five copies of the same snapshot for one file, minted by successive pulls.

## The fix

```go
func (s *Syncer) isExcluded(relPath string) bool {
	// Per-machine debris never syncs, regardless of user excludes.
	base := filepath.Base(relPath)
	if base == ".lock" || conflictArtifactRe.MatchString(base) {
		return true
	}
	return s.cfg.IsExcluded(relPath)
}
```

Unconditional and ahead of the user's patterns, because neither file has meaning on another machine under any configuration. This also sidesteps the globstar matching in #43 — no pattern needs to be written or matched.

## Why the regex is anchored

```go
var conflictArtifactRe = regexp.MustCompile(`\.conflict\.\d{8}-\d{6}$`)
```

It matches only the `<yyyymmdd>-<hhmmss>` format `handleConflict` writes, not any name containing `.conflict.`.

This is the load-bearing detail. **Excluding a path that is already tracked in state makes the next push report it as a deletion and prune it from the bucket.** A loose `*.conflict.*` would therefore remotely delete a user file called `notes.conflict.md`. The tests pin both directions: `notes.conflict.md`, `my.conflict.2026.txt`, a truncated timestamp, `package.lock`, and `.lockfile` all stay; the real artifacts go.

## Migration note

The first push after upgrading prunes already-uploaded locks and conflict artifacts from the bucket. Local copies are untouched — this is cleanup, not data loss, but it is worth a line in release notes since the remote objects do disappear. In our fleet it removed 12 lock files and the stale conflict artifacts in one push.

## Scope and tests

1 file changed in `internal/sync/`, +18 lines, plus a new test file. `go vet ./...` and `go test ./...` green on Linux/ext4.

- `TestIsExcludedSkipsPerMachineDebris` — both classes excluded; 8 near-miss names explicitly kept
- `TestIsExcludedStillHonorsUserPatterns` — user `exclude` config still applies
- `TestPushSkipsDebrisFiles` — end-to-end: only the transcript reaches the bucket, and the local `.lock` is still on disk afterwards

Happy to adjust the naming or fold the two classes into separate predicates if you prefer.
