### PR TITLE
fix: make content path mapping separator- and escaping-aware

### DIFF
--- a/internal/sync/paths.go
+++ b/internal/sync/paths.go
@@ -27,17 +27,49 @@ import (
 // HOME is always mapped. Additional prefixes (e.g. ~/work on one machine,
 // ~/Projects on another) can be mapped via the path_map config, with both
 // machines pointing their own local path at the same token name.
+//
+// Content rewriting is separator- and escaping-aware, because a Windows device
+// and a POSIX device do not spell the same path the same way. Remotely, path
+// tails are always canonicalized to "/" separators; on pull they are rendered
+// with the local separator, escaped for the file format being written.
 type PathMapper struct {
 	// mappings ordered longest local path first so the most specific prefix wins
 	mappings []pathMapping
 }
 
+// pathContentKind describes how a file format spells a path, which decides both
+// what to match on push and what to emit on pull.
+type pathContentKind int
+
+const (
+	// pathContentPlain holds paths verbatim (.md, .txt).
+	pathContentPlain pathContentKind = iota
+	// pathContentJSON escapes a backslash as a pair (.json, .jsonl), so a Windows
+	// path reads as C:\\Users\\bob. Writing a raw backslash into one of these
+	// produces an invalid escape sequence and the file stops parsing.
+	pathContentJSON
+	numPathContentKinds
+)
+
+// pathSegment matches one path component. Deliberately conservative: a tail
+// stops at the first character that is not plainly part of a file name, so
+// prose following a path is never rewritten.
+const pathSegment = `[A-Za-z0-9_.-]*`
+
 type pathMapping struct {
 	name      string // token name, e.g. "HOME", "WORK"
-	localPath string // absolute local path, no trailing slash
+	localPath string // absolute local path, no trailing separator
 	encLocal  string // localPath in Claude Code's directory encoding
-	normRe    *regexp.Regexp
-	normRepl  []byte // replacement template: token ($-escaped) + boundary group
+	windows   bool   // localPath uses backslash separators
+
+	// normRe matches this device's spelling of localPath (plus any path tail)
+	// for a given content kind; localIn is how localPath is written back out.
+	normRe  [numPathContentKinds]*regexp.Regexp
+	localIn [numPathContentKinds]string
+
+	// resolveRe matches the portable token and its canonical "/" tail. The
+	// token is self-delimiting, so no trailing boundary is needed.
+	resolveRe *regexp.Regexp
 }
 
 var pathTokenNameRe = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
@@ -48,25 +80,38 @@ func NewPathMapper(homeDir string, userMap map[string]string) (*PathMapper, erro
 	m := &PathMapper{}
 
 	add := func(name, localPath string) error {
-		localPath = strings.TrimRight(localPath, "/")
+		localPath = strings.TrimRight(localPath, `/\`)
 		if localPath == "" {
 			return nil
 		}
 		if !pathTokenNameRe.MatchString(name) {
 			return fmt.Errorf("invalid path_map token %q: use uppercase letters, digits, underscores (e.g. WORK)", name)
 		}
-		// Boundary-aware: only replace the path when it is not followed by a
-		// name character, so /Users/merv never matches inside /Users/mervynlally.
-		re := regexp.MustCompile(regexp.QuoteMeta(localPath) + `([^A-Za-z0-9_.-]|$)`)
-		m.mappings = append(m.mappings, pathMapping{
+
+		mp := pathMapping{
 			name:      name,
 			localPath: localPath,
 			encLocal:  EncodeClaudePath(localPath),
-			normRe:    re,
-			// "$$" = literal "$" in a regexp replacement template; without it
-			// "${HOME}" would itself be read as a group reference
-			normRepl: []byte("$${" + name + "}${1}"),
-		})
+			windows:   strings.Contains(localPath, `\`),
+		}
+
+		for _, kind := range []pathContentKind{pathContentPlain, pathContentJSON} {
+			// Only the root's native spelling is matched. Windows also accepts
+			// C:/like/this, but that form shows up mostly inside quoted error
+			// text and tool output, and rewriting a device's own prose is worse
+			// than leaving one uncommon spelling unmapped.
+			root := regexp.QuoteMeta(renderLocalPath(localPath, kind, mp.windows))
+			tail := `((?:` + separatorPattern(kind) + pathSegment + `)*)`
+			// Boundary-aware: only replace the path when it is not followed by a
+			// name character, so /Users/merv never matches inside /Users/mervynlally.
+			boundary := `([^A-Za-z0-9_.-]|$)`
+			mp.normRe[kind] = regexp.MustCompile(root + tail + boundary)
+			mp.localIn[kind] = renderLocalPath(localPath, kind, mp.windows)
+		}
+
+		mp.resolveRe = regexp.MustCompile(regexp.QuoteMeta(pathToken(name)) + `((?:/` + pathSegment + `)*)`)
+
+		m.mappings = append(m.mappings, mp)
 		return nil
 	}
 
@@ -90,6 +135,47 @@ func NewPathMapper(homeDir string, userMap map[string]string) (*PathMapper, erro
 	})
 
 	return m, nil
+}
+
+// separatorPattern matches a path separator as it appears in this content kind:
+// a forward slash, or a backslash spelled the way the format escapes it.
+func separatorPattern(kind pathContentKind) string {
+	if kind == pathContentJSON {
+		return `(?:\\\\|/)`
+	}
+	return `(?:\\|/)`
+}
+
+// renderLocalPath spells an absolute local path for the given content kind.
+func renderLocalPath(p string, kind pathContentKind, windows bool) string {
+	if windows && kind == pathContentJSON {
+		return strings.ReplaceAll(p, `\`, `\\`)
+	}
+	return p
+}
+
+// localSeparator is the separator to emit for this device and content kind.
+func localSeparator(kind pathContentKind, windows bool) string {
+	if !windows {
+		return "/"
+	}
+	if kind == pathContentJSON {
+		return `\\`
+	}
+	return `\`
+}
+
+// pathContentKindFor reports how the file at relPath spells paths. Conflict copies
+// (path.conflict.<timestamp>) inherit the base path's format.
+func pathContentKindFor(relPath string) pathContentKind {
+	if i := strings.Index(relPath, ".conflict."); i >= 0 {
+		relPath = relPath[:i]
+	}
+	switch path.Ext(relPath) {
+	case ".json", ".jsonl":
+		return pathContentJSON
+	}
+	return pathContentPlain
 }
 
 // EncodeClaudePath applies Claude Code's project directory encoding: every
@@ -170,27 +256,71 @@ func (m *PathMapper) ResolveRelPath(relPath string) (string, bool) {
 }
 
 // NormalizeContent replaces this device's mapped path prefixes with portable
-// tokens in file content. Replacement is boundary-aware so one user's home
-// path never matches inside a longer username.
-func (m *PathMapper) NormalizeContent(data []byte) []byte {
+// tokens in the content of the file at relPath. Replacement is boundary-aware
+// so one user's home path never matches inside a longer username, and the
+// matched path tail is canonicalized to "/" separators so a Windows device and
+// a POSIX device produce byte-identical remote content.
+func (m *PathMapper) NormalizeContent(relPath string, data []byte) []byte {
 	if m == nil {
 		return data
 	}
-	for _, mp := range m.mappings {
-		data = mp.normRe.ReplaceAll(data, mp.normRepl)
+	kind := pathContentKindFor(relPath)
+	for i := range m.mappings {
+		mp := &m.mappings[i]
+		re := mp.normRe[kind]
+		token := []byte(pathToken(mp.name))
+		data = re.ReplaceAllFunc(data, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			if sub == nil {
+				return match
+			}
+			out := make([]byte, 0, len(token)+len(sub[1])+len(sub[2]))
+			out = append(out, token...)
+			out = append(out, canonicalizeTail(sub[1], kind)...)
+			out = append(out, sub[2]...)
+			return out
+		})
 	}
 	return data
 }
 
-// ResolveContent replaces portable tokens with this device's local paths.
-func (m *PathMapper) ResolveContent(data []byte) []byte {
+// ResolveContent replaces portable tokens with this device's local paths,
+// rendering separators and escaping for the format of the file at relPath.
+func (m *PathMapper) ResolveContent(relPath string, data []byte) []byte {
 	if m == nil {
 		return data
 	}
-	for _, mp := range m.mappings {
-		data = bytes.ReplaceAll(data, []byte(pathToken(mp.name)), []byte(mp.localPath))
+	kind := pathContentKindFor(relPath)
+	for i := range m.mappings {
+		mp := &m.mappings[i]
+		re := mp.resolveRe
+		local := []byte(mp.localIn[kind])
+		sep := []byte(localSeparator(kind, mp.windows))
+		data = re.ReplaceAllFunc(data, func(match []byte) []byte {
+			sub := re.FindSubmatch(match)
+			if sub == nil {
+				return match
+			}
+			tail := sub[1]
+			if mp.windows {
+				tail = bytes.ReplaceAll(tail, []byte("/"), sep)
+			}
+			out := make([]byte, 0, len(local)+len(tail))
+			out = append(out, local...)
+			out = append(out, tail...)
+			return out
+		})
 	}
 	return data
+}
+
+// canonicalizeTail rewrites the separators of a matched path tail to "/" so the
+// remote form does not depend on which OS pushed it.
+func canonicalizeTail(tail []byte, kind pathContentKind) []byte {
+	if kind == pathContentJSON {
+		return bytes.ReplaceAll(tail, []byte(`\\`), []byte("/"))
+	}
+	return bytes.ReplaceAll(tail, []byte(`\`), []byte("/"))
 }
 
 // IsPortableContentPath reports whether content path translation applies to

--- a/internal/sync/paths_crossos_test.go
+++ b/internal/sync/paths_crossos_test.go
@@ -1,0 +1,166 @@
+package sync
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Cross-OS content mapping. A Windows device and a POSIX device spell the same
+// project path differently, and .jsonl escapes a backslash as a pair, so the
+// normalized remote form has to be separator- and escaping-neutral.
+
+const (
+	posixHome = `/Users/alice`
+	posixRoot = `/Users/alice/projects`
+	winHome   = `C:\Users\bob`
+	winRoot   = `D:\projects`
+	winRoot2  = `C:\work\projects`
+
+	// Underscore and dash both belong to a path segment, so a name using them
+	// exercises the boundary rules.
+	project = `my_app-dev`
+
+	sessionFile = "projects/whatever/s.jsonl"
+	memoFile    = "projects/whatever/memory/note.md"
+)
+
+func mapperFor(t *testing.T, home, root string) *PathMapper {
+	t.Helper()
+	m, err := NewPathMapper(home, map[string]string{root: "WORK"})
+	if err != nil {
+		t.Fatalf("NewPathMapper(%q, %q): %v", home, root, err)
+	}
+	return m
+}
+
+func TestContentNormalizesToSameRemoteFormOnEveryOS(t *testing.T) {
+	posix := mapperFor(t, posixHome, posixRoot)
+	win := mapperFor(t, winHome, winRoot)
+
+	want := `{"cwd":"${WORK}/my_app-dev"}`
+
+	got := string(posix.NormalizeContent(sessionFile, []byte(`{"cwd":"/Users/alice/projects/my_app-dev"}`)))
+	if got != want {
+		t.Errorf("posix normalize = %s, want %s", got, want)
+	}
+
+	got = string(win.NormalizeContent(sessionFile, []byte(`{"cwd":"D:\\projects\\my_app-dev"}`)))
+	if got != want {
+		t.Errorf("windows normalize = %s, want %s", got, want)
+	}
+
+	// A Windows root spelled with forward slashes is deliberately left alone:
+	// that form appears mostly in quoted error text and tool output, where
+	// rewriting the device's own prose would be worse than leaving it unmapped.
+	prose := `{"text":"failed at D:/projects/my_app-dev"}`
+	if got := string(win.NormalizeContent(sessionFile, []byte(prose))); got != prose {
+		t.Errorf("forward-slash root = %s, should be untouched", got)
+	}
+}
+
+func TestContentRoundTripAcrossOS(t *testing.T) {
+	posix := mapperFor(t, posixHome, posixRoot)
+	win := mapperFor(t, winHome, winRoot2)
+
+	cases := []struct {
+		name     string
+		from, to *PathMapper
+		relPath  string
+		in, want string
+	}{
+		{
+			name:    "posix to windows, jsonl stays valid JSON",
+			from:    posix,
+			to:      win,
+			relPath: sessionFile,
+			in:      `{"cwd":"/Users/alice/projects/my_app-dev","home":"/Users/alice/.claude"}`,
+			want:    `{"cwd":"C:\\work\\projects\\my_app-dev","home":"C:\\Users\\bob\\.claude"}`,
+		},
+		{
+			name:    "windows to posix, jsonl",
+			from:    win,
+			to:      posix,
+			relPath: sessionFile,
+			in:      `{"cwd":"C:\\work\\projects\\my_app-dev","home":"C:\\Users\\bob\\.claude"}`,
+			want:    `{"cwd":"/Users/alice/projects/my_app-dev","home":"/Users/alice/.claude"}`,
+		},
+		{
+			name:    "windows to posix, markdown keeps raw separators",
+			from:    win,
+			to:      posix,
+			relPath: memoFile,
+			in:      `see C:\work\projects\my_app-dev for details`,
+			want:    `see /Users/alice/projects/my_app-dev for details`,
+		},
+		{
+			name:    "posix to windows, markdown",
+			from:    posix,
+			to:      win,
+			relPath: memoFile,
+			in:      `see /Users/alice/projects/my_app-dev for details`,
+			want:    `see C:\work\projects\my_app-dev for details`,
+		},
+		{
+			name:    "windows to windows is unchanged end to end",
+			from:    win,
+			to:      win,
+			relPath: sessionFile,
+			in:      `{"cwd":"C:\\work\\projects\\my_app-dev"}`,
+			want:    `{"cwd":"C:\\work\\projects\\my_app-dev"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			norm := tc.from.NormalizeContent(tc.relPath, []byte(tc.in))
+			got := string(tc.to.ResolveContent(tc.relPath, norm))
+			if got != tc.want {
+				t.Errorf("round trip = %s\nwant                = %s\n(remote form was %s)", got, tc.want, norm)
+			}
+		})
+	}
+}
+
+func TestResolvedJSONStaysParseable(t *testing.T) {
+	posix := mapperFor(t, posixHome, posixRoot)
+	win := mapperFor(t, winHome, winRoot)
+
+	in := []byte(`{"cwd":"/Users/alice/projects/my_app-dev","home":"/Users/alice/.claude"}`)
+	out := win.ResolveContent(sessionFile, posix.NormalizeContent(sessionFile, in))
+
+	var v map[string]any
+	if err := json.Unmarshal(out, &v); err != nil {
+		t.Fatalf("resolved content is not valid JSON: %v\ncontent: %s", err, out)
+	}
+	if v["cwd"] != `D:\projects\my_app-dev` {
+		t.Errorf("decoded cwd = %v", v["cwd"])
+	}
+}
+
+func TestWindowsBoundariesNotOverMatched(t *testing.T) {
+	win := mapperFor(t, winHome, winRoot)
+
+	// A longer sibling directory must not match the mapped root.
+	for _, s := range []string{
+		`{"cwd":"D:\\projectsOther\\x"}`,
+		`{"cwd":"D:\\projects-archive\\x"}`,
+	} {
+		if got := string(win.NormalizeContent(sessionFile, []byte(s))); got != s {
+			t.Errorf("NormalizeContent(%s) = %s, should be untouched", s, got)
+		}
+	}
+}
+
+func TestRemoteKeysMapAcrossOS(t *testing.T) {
+	posix := mapperFor(t, posixHome, posixRoot)
+	win := mapperFor(t, winHome, winRoot2)
+
+	local := "projects/" + EncodeClaudePath(posixRoot+"/"+project) + "/s.jsonl"
+	remote := posix.NormalizeRelPath(local)
+	got, ok := win.ResolveRelPath(remote)
+
+	want := "projects/" + EncodeClaudePath(winRoot2+`\`+project) + "/s.jsonl"
+	if !ok || got != want {
+		t.Errorf("ResolveRelPath(%q) = %q (ok=%v), want %q", remote, got, ok, want)
+	}
+}

--- a/internal/sync/paths_test.go
+++ b/internal/sync/paths_test.go
@@ -113,14 +113,14 @@ func TestContentRoundTrip(t *testing.T) {
 	bob := mustMapper(t, "/Users/mervynlally", nil)
 
 	in := []byte(`{"cwd":"/Users/merv/nexura","note":"see /Users/mervynlally/nexura and /Users/merv"}`)
-	norm := alice.NormalizeContent(in)
+	norm := alice.NormalizeContent("projects/-Users-merv-nexura/s.jsonl", in)
 
 	want := `{"cwd":"${HOME}/nexura","note":"see /Users/mervynlally/nexura and ${HOME}"}`
 	if string(norm) != want {
 		t.Fatalf("NormalizeContent = %s, want %s", norm, want)
 	}
 
-	resolved := bob.ResolveContent(norm)
+	resolved := bob.ResolveContent("projects/-Users-merv-nexura/s.jsonl", norm)
 	wantResolved := `{"cwd":"/Users/mervynlally/nexura","note":"see /Users/mervynlally/nexura and /Users/mervynlally"}`
 	if string(resolved) != wantResolved {
 		t.Fatalf("ResolveContent = %s, want %s", resolved, wantResolved)
@@ -132,12 +132,12 @@ func TestContentBoundaries(t *testing.T) {
 
 	// dotted and dashed continuations are part of a different name, not a boundary
 	for _, s := range []string{"/Users/merv.bak/x", "/Users/merv-old/x", "/Users/mervyn/x"} {
-		if got := m.NormalizeContent([]byte(s)); string(got) != s {
+		if got := m.NormalizeContent("projects/x/notes.md", []byte(s)); string(got) != s {
 			t.Errorf("NormalizeContent(%q) = %q, should be untouched", s, got)
 		}
 	}
 	// end of data is a boundary
-	if got := m.NormalizeContent([]byte("/Users/merv")); string(got) != "${HOME}" {
+	if got := m.NormalizeContent("projects/x/notes.md", []byte("/Users/merv")); string(got) != "${HOME}" {
 		t.Errorf("NormalizeContent at EOF = %q", got)
 	}
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -432,7 +432,7 @@ func (s *Syncer) uploadFile(ctx context.Context, relativePath string) error {
 
 	// Replace machine-specific paths with portable tokens in session content
 	if IsPortableContentPath(relativePath) {
-		data = s.paths.NormalizeContent(data)
+		data = s.paths.NormalizeContent(relativePath, data)
 	}
 
 	// Compress
@@ -487,7 +487,7 @@ func (s *Syncer) downloadFile(ctx context.Context, relativePath, remoteKey strin
 
 	// Replace portable tokens with this device's paths in session content
 	if IsPortableContentPath(relativePath) {
-		data = s.paths.ResolveContent(data)
+		data = s.paths.ResolveContent(relativePath, data)
 	}
 
 	// Guard against path traversal from crafted remote keys


### PR DESCRIPTION
## Problem

Content path translation is not safe across operating systems. `NormalizeContent` / `ResolveContent` operate on raw bytes using a single spelling of the mapped path, but `.jsonl` and `.json` escape a backslash as a pair. A Windows device therefore never matches its own paths, and two things go wrong.

**1. Windows content is never made portable.** A transcript stores `"cwd":"H:\\Github\\Dev\\my-app"`, while the mapper looks for `H:\Github\Dev`. No match, so the content uploads unnormalized and a POSIX device pulling it gets a path it cannot use.

**2. Pulling POSIX-authored sessions onto Windows writes invalid JSON.** The reverse direction does match, so the remote holds `"cwd":"${WORK}/my-app"`. On pull, a Windows device substitutes the token with a raw backslash path, producing:

```json
{"cwd":"H:\Github\Dev\my-app"}
```

`\G` is not a valid JSON escape. The `.jsonl` no longer parses — `invalid character 'G' in string escape code`. The same applies to the automatic `${HOME}` token, so this reproduces with no `path_map` configured at all.

Minimal repro against `main`:

```go
posix, _ := NewPathMapper("/Users/alice", map[string]string{"/Users/alice/work": "WORK"})
win, _ := NewPathMapper(`C:\Users\bob`, map[string]string{`H:\work`: "WORK"})

norm := posix.NormalizeContent([]byte(`{"cwd":"/Users/alice/work/app"}`))
out := win.ResolveContent(norm)
// {"cwd":"H:\work\app"}  -> json.Unmarshal fails
```

Remote **key** mapping is unaffected and already correct, because `EncodeClaudePath` flattens every non-alphanumeric character. Only file content is affected.

## Fix

`NormalizeContent` and `ResolveContent` now take the file's relative path and derive a content kind from its extension:

- `.json` / `.jsonl` — a backslash is escaped as a pair
- `.md` / `.txt` — a backslash is verbatim

Matched path tails are canonicalized to `/` in the remote form, so a Windows device and a POSIX device produce **byte-identical remote content** for the same logical path. On pull the token is rendered with the local separator, escaped for the format being written.

Only the root's native spelling is matched. Windows also accepts `C:/like/this`, but that form shows up mostly inside quoted error text and tool output; rewriting a device's own prose is worse than leaving one uncommon spelling unmapped. This was not a hypothetical — an early revision matched it and rewrote a PowerShell error message quoted inside a real transcript.

## Testing

New `internal/sync/paths_crossos_test.go`:

- both operating systems normalize the same logical path to the same remote bytes
- round trips in both directions, for both content kinds
- resolved JSON stays parseable, with the decoded `cwd` checked
- a Windows root does not over-match a longer sibling directory (`H:\Github\Development`)

Existing tests keep their original expectations; only the call signature changed.

Also validated outside the test suite against 57 real transcripts on a Windows device: 35 of the 36 files containing a mapped path round-trip byte-identically on the same device, and all 57 stay valid JSON after a POSIX device resolves them. The single exclusion is a transcript quoting a literal `${HOME}`, which is the pre-existing token ambiguity already documented on `pathToken`.

End-to-end on a real R2 bucket across a Windows and a macOS device: 28 files pulled macOS → Windows, 3379 JSONL lines, zero parse failures, `${WORK}` and `${HOME}` both resolving to the correct local roots.

`gofmt` and `go vet` are clean. On Windows six tests fail both before and after this change, all asserting Unix file modes (`0600` vs `666`); they pass on Linux CI.

## Compatibility

Content already on a bucket is untouched and still readable. Windows-authored files uploaded before this change were never normalized, so they carry absolute Windows paths; they become portable the next time that device pushes them. Files whose content was already tokenized resolve correctly under the new code.
